### PR TITLE
Trellis: Add docs for Ansible Vault

### DIFF
--- a/trellis/deploys.md
+++ b/trellis/deploys.md
@@ -95,7 +95,7 @@ vars:
   deploy_finalize_after: "{{ playbook_dir }}/roles/deploy/hooks/finalize-after.yml"
 ```
 
-### SSH Keys
+### SSH keys
 
 Before you can deploy a site to a remote server, your SSH keys need to be working. Trellis takes advantage of SSH forwarding so your remote server does need to generate an SSH key and add it to GitHub/Bitbucket.
 
@@ -133,7 +133,8 @@ wordpress_sites:
       wp_env: production
       db_name: mysite_prod
       db_user: mysite_dbuser
-      db_password: mysite_dbpassword
+      # Define the following variables in group_vars/production/vault.yml
+      # db_password:
 ```
 
 Deploy command:

--- a/trellis/local-development-setup.md
+++ b/trellis/local-development-setup.md
@@ -16,7 +16,7 @@ docs_project:
 publish_to_discourse:
   - "0"
 ---
-Configure the sites on your Vagrant development VM by editing `group_vars/development/wordpress_sites.yml`.
+Configure the sites on your Vagrant development VM by editing `group_vars/development/wordpress_sites.yml` and `group_vars/development/vault`.
 
 `wordpress_sites` is the top-level dictionary used to define the WordPress sites, databases, Nginx vhosts, etc that will be created. Each site's variables are nested under a site "key" (e.g., `example.com`). This key is just a descriptive name and serves as the default value for some variables. See our [example project](https://github.com/roots/roots-example-project.com/blob/master/trellis/group_vars/development/wordpress_sites.yml) for a complete working example.
 
@@ -33,7 +33,7 @@ Configure the sites on your Vagrant development VM by editing `group_vars/develo
 * `system_cron` - Disable WP cron and use system's (default: `true`)
 * `admin_user` - WP admin user name (*development* only, required)
 * `admin_email` - WP admin email address (*development* only, required)
-* `admin_password` - WP admin user password (*development* only, required)
+* `admin_password` - WP admin user password (*development* only, required, in `vault.yml`)
 * `multisite` - hash of multisite options. See the [Multisite docs](https://roots.io/trellis/docs/multisite/).
   * `enabled` - Multisite enabled flag (required, set to `false`)
   * `subdomains` - subdomains option
@@ -47,7 +47,7 @@ Configure the sites on your Vagrant development VM by editing `group_vars/develo
   * `wp_env` - environment (required, matches group name: `development`, `staging`, `production`)
   * `db_name` - database name (required)
   * `db_user` - database username (required)
-  * `db_password` - database password (required)
+  * `db_password` - database password (required, in `vault.yml`)
   * `db_host` - database hostname (default: `localhost`)
   * `domain_current_site` (required if multisite.enabled is `true`)
 

--- a/trellis/mail.md
+++ b/trellis/mail.md
@@ -49,11 +49,13 @@ All of these offer around 10k+ emails for free per month. Once you have SMTP cre
 * `mail_smtp_server`: hostname:port
 * `mail_hostname`: hostname for mail delivery
 * `mail_user`: username
-* `mail_password`: password (or API key)
+* `mail_password`: password or API key (define in `group_vars/all/vault.yml`)
 
 ### Example
 
-* `mail_smtp_server`: `smtp.example.com:587`
-* `mail_hostname`: `example.com`
-* `mail_user`: `admin@example.com`
-* `mail_password`: `password`
+```yml
+mail_smtp_server: smtp.example.com:587
+mail_hostname: example.com
+mail_user: admin@example.com
+mail_password: "{{ vault_mail_password }}" # Define this in group_vars/all/vault.yml
+```

--- a/trellis/passwords.md
+++ b/trellis/passwords.md
@@ -12,19 +12,15 @@ docs_project:
 publish_to_discourse:
   - "0"
 ---
-There a few places you'll want to set/change passwords:
+There are a few places you'll want to set/change passwords:
 
-* `group_vars/<environment>/main.yml` - `mysql_root_password`
-* `group_vars/<environment>/wordpress_sites.yml` - `wordpress_sites.admin_password`
-* `group_vars/<environment>/wordpress_sites.yml` - `wordpress_sites.env.db_password`
+* `group_vars/<environment>/vault.yml` - `vault_mysql_root_password`
+* `group_vars/<environment>/vault.yml` - `vault_sudoer_passwords`
+* `group_vars/development/vault.yml` - `vault_wordpress_sites.admin_password`
+* `group_vars/<environment>/vault.yml` - `vault_wordpress_sites.env.db_password`
 
 For staging/production environments, it's best to randomly generate longer passwords using something like [random.org](http://www.random.org/passwords/).
 
-You may be concerned about setting plaintext passwords in a Git repository, and you should be. Any type of server configs such as this playbook should always be in a **private** Git repository.
+You may be concerned about setting plaintext passwords in a Git repository, and you should be. We strongly recommend you encrypt these passwords before committing them to your repo. Trellis is structured to make it easy to enable [Ansible Vault](https://roots.io/trellis/docs/vault/) to encrypt select files. Alternatively, you could try an option such as [Git Encrypt](https://github.com/shadowhand/git-encrypt).
 
-Even then it's still best to try avoid it if possible, so you have few options:
-
-* Use [Ansible Vault](http://docs.ansible.com/playbooks_vault.html)
-* Use [Git Encrypt](https://github.com/shadowhand/git-encrypt)
-
-Note: if you're mostly using this for development environments only, you probably don't need to worry about any of this as everything is just run locally.
+Note: Any type of server configs such as this playbook should always be in a **private** Git repository.

--- a/trellis/remote-server-setup.md
+++ b/trellis/remote-server-setup.md
@@ -15,7 +15,7 @@ publish_to_discourse:
 ---
 Setting up remote servers (staging/production) is similar to the [local development setup](https://roots.io/trellis/docs/local-development-setup/).
 
-1. Configure your WordPress sites in `group_vars/<environment>/wordpress_sites.yml`. Also see the [Passwords docs](https://roots.io/trellis/docs/passwords/). `wordpress_sites.yml` for remote servers have a few more settings than your local development server:
+1. Configure your WordPress sites in `group_vars/<environment>/wordpress_sites.yml` and `group_vars/development/vault.yml`. Also see the [Passwords docs](https://roots.io/trellis/docs/passwords/). `wordpress_sites.yml` for remote servers have a few more settings than your local development server:
   * `repo` - URL of the Git repo of your Bedrock project (required, used when deploying)
   * `branch` - the branch name, tag name, or commit SHA1 you want to deploy (default: `master`)
   * `subtree_path` - relative path to your Bedrock/WP directory in your repo (above) if its not the root (like in the [roots-example-project](https://github.com/roots/roots-example-project.com))

--- a/trellis/security.md
+++ b/trellis/security.md
@@ -21,7 +21,7 @@ publish_to_discourse:
 The `sshd` role heightens your server's security by providing better SSH defaults, disabling password authentication for SSH access, and optionally disabling SSH `root` login. To disable `root` login:
 
 * Set `sshd_permit_root_login: false` in `group_vars/all/security.yml`
-* Set a password for the `admin_user` user (see below)
+* Set a sudoer password for the `admin_user` user (see below)
 * Run the `server.yml` playbook (see note about `--ask-become-pass` in "Admin User" section below)
 
 You may toggle `sshd_permit_root_login` between `true` or `false` on a server that is already provisioned.
@@ -38,12 +38,12 @@ This prompts you to enter the sudoer password described in the "Admin User Sudoe
 
 ## Admin user sudoer password
 
-While `server.yml` provisions your server as the `admin_user`, it will perform some operations using `sudo` with a password. You will need to set the sudoer password for `admin` in the list of `sudoer_passwords` defined in `vars/sudoer_passwords.yml`. Here is an example:
+While `server.yml` provisions your server as the `admin_user`, it will perform some operations using `sudo` with a password. You will need to set the sudoer password for `admin` in the list of `vault_sudoer_passwords` defined in `group_vars/<environment>/vault.yml`. Here is an example:
 
 ```yaml
-sudoer_passwords:
+vault_sudoer_passwords:
   admin: $6$rounds=100000$JUkj1d3hCa6uFp6R$3rZ8jImyCpTP40e4I5APx7SbBvDCM8fB6GP/IGOrsk/GEUTUhl1i/Q2JNOpj9ashLpkgaCxqMqbFKdZdmAh26/
   another_user: $6$rounds=100000$r3ZZsk/uc31cAxQT$YHMkmKrwgXr3u1YgrSvg0wHZg5IM6MLEzqOraIXqh5o7aWshxD.QaNeCcUX3KInqzTqaqN3qzo9nvc/QI0M1C.
 ```
 
-The passwords were generated using the python command [found here](http://docs.ansible.com/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module). The passwords generated here are `example_password` and `another_password`, respectively. The ansible user module doesn't handle any encryption and passwords must be encrypted beforehand. It's also recommended `vars/sudoer_passwords.yml` be encrypted using one of the encryption methods described on the [passwords](https://roots.io/trellis/docs/passwords/) page in the docs. Passwords are stored separately in order to ease the separation of encrypted var files and are looked up based on the user name.
+The passwords were generated using the python command [found here](http://docs.ansible.com/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module). The passwords generated here are `example_password` and `another_password`, respectively. The ansible user module doesn't handle any encryption and passwords must be encrypted beforehand. It's also recommended `group_vars/<environment>/vault.yml` be encrypted using [Ansible Vault](https://roots.io/trellis/docs/vault/).

--- a/trellis/vault.md
+++ b/trellis/vault.md
@@ -16,4 +16,84 @@ docs_project:
 publish_to_discourse:
   - 'a:1:{i:0;s:1:"0";}'
 ---
-Coming soon. See the [pending pull request](https://github.com/roots/trellis/pull/317).
+Some Ansible variables contain sensitive data such as passwords. Trellis keeps these variable definitions in separate files named `vault.yml`. We strongly recommend that you encrypt these `vault.yml` files using [Ansible Vault](http://docs.ansible.com/ansible/playbooks_vault.html) to avoid exposing sensitive data in your project repo. Your Trellis commands will be exactly the same as before enabling vault, not requiring any extra flags.
+
+To briefly demonstrate what vault does, consider this example `vault.yml` file.
+
+```yml
+# example vault.yml file -- unencrypted plain text
+my_password: example_password
+```
+
+You should replace the `example_password` then encrypt the file with Ansible Vault before committing it to your repo. The data would be safe in your repo because the encrypted file would look like this:
+
+```yml
+# example vault.yml file -- encrypted
+$ANSIBLE_VAULT;1.1;AES256
+343163646662643438323831343332626234333233386666333162383265663
+3132306538383762336332376165383530633838643937320a6363343238643
+363065366664316364646561613163653866623566303235666537343437643
+6638363265383831390a6631663239373833636133623333666363643166383
+6237663637353638653266616562616535623465636265316231613331 etc.
+```
+
+## Steps to enable Ansible Vault
+
+### 1. Set vault password
+
+Generate a long random password and save it as a string on a single line in a new file. Name the file `.vault_pass` and save it at the root of this project (e.g., next to `ansible.cfg`). You will probably want to run `chmod 600 .vault_pass` to restrict access to this file. This `.vault_pass` file will remain in plain text and should _not_ be committed to your repo, so be sure that it is included in your `.gitignore` file.
+
+If you prefer not to create a file with your vault password, you can add the `--ask-vault-pass` flag to your `ansible-playbook` commands, which will prompt you to enter your password via the command line.
+
+### 2. Inform Ansible of vault password
+
+The easiest way to inform Ansible of your vault password is to list your `.vault_pass` file as a default in `ansible.cfg`:
+
+```diff
+  # ansible.cfg
+  [defaults]
+  roles_path = vendor/roles
+  force_handlers = True
+  inventory = hosts
++ vault_password_file = .vault_pass
+```
+
+If you prefer not to set this default in your `ansible.cfg` file, you can add the `--vault-password-file .vault_pass` flag to your `ansible-playbook` commands. Alternatively, you could add the `--ask-vault-pass` flag, causing the `ansible-playbook` command to prompt you to enter your password via the command line.
+
+### 3. Encrypt files
+
+**Caution:** If you have unencrypted `vault.yml` files in your project's git history (e.g., passwords in plain text), you will most likely want to change the variable values in your `vault.yml` files before encrypting them and committing them to your repo.
+
+Encrypt your `vault.yml` files with the command `ansible-vault encrypt <file>`. The example below uses the command to encrypt the full list of `vault.yml` files (fileglobs are not supported, issue 6241 at ansible/ansible):
+
+```
+ansible-vault encrypt group_vars/all/vault.yml group_vars/development/vault.yml group_vars/staging/vault.yml group_vars/production/vault.yml
+```
+
+## Other vault commands
+
+Here are a few notable commands from the official [Ansible Vault](http://docs.ansible.com/ansible/playbooks_vault.html) docs.
+
+* [`ansible-vault encrypt <file>`](http://docs.ansible.com/ansible/playbooks_vault.html#encrypting-unencrypted-files)
+* [`ansible-vault view <file>`](http://docs.ansible.com/ansible/playbooks_vault.html#viewing-encrypted-files)
+* [`ansible-vault edit <file>`](http://docs.ansible.com/ansible/playbooks_vault.html#editing-encrypted-files)
+* [`ansible-vault decrypt <file>`](http://docs.ansible.com/ansible/playbooks_vault.html#decrypting-encrypted-files) -- Avoid using the `decrypt` command. If your intention is to view or edit an encrypted file, use the `view` or `edit` commands instead. Any time you decrypt a file, you risk forgetting to re-encrypt the file before committing changes to your repo.
+* [`ansible-vault rekey <file>`](http://docs.ansible.com/ansible/playbooks_vault.html#rekeying-encrypted-files)
+
+## Working with vault variables
+
+Here are a few conceptual tips for working with [variables and vault](http://docs.ansible.com/ansible/playbooks_best_practices.html#variables-and-vaults) in Trellis.
+
+* Variables with sensitive data such as passwords are defined in files named `vault.yml`.
+* Each environment has its own `vault.yml` file: `group_vars/<environment>/vault.yml`.
+* There is also one `vault.yml` file applicable to all environments: `group_vars/all/vault.yml`.
+* Variables named with the `vault_` prefix are defined in the `vault.yml` files.
+* To view or edit an encrypted `vault.yml` file, use either `ansible-vault view <file>` or `ansible-vault edit <file>`. Avoid using the `decrypt` command. Any time you decrypt a file, you risk forgetting to re-encrypt the file before committing changes to your repo. You may want to employ a pre-commit hook ([example](https://www.reinteractive.net/posts/167-ansible-real-life-good-practices)) for added prevention.
+
+## Sharing a project with vault-encrypted files
+
+Your repo with vault-encrypted files is secure from anyone being able to see or use the sensitive data in the `vault.yml` files. To grant a colleague access to the data, you will need to give your colleague your vault password to use in repeating the two password steps in the [Steps to Enable Ansible Vault](https://roots.io/trellis/docs/vault/#steps-to-enable-ansible-vault) above. It is still recommended to always keep your project in a private repo.
+
+## Disabling Ansible Vault
+
+It is not recommended to disable Ansible Vault but you can disable it at any time. Simply run `ansible-vault decrypt <file1> <file2> <etc>`. If you then commit the unencrypted files to your repo, the sensitive data will be in your repo in plain text and will be difficult to remove from the git history. If you re-enable vault in the future, you may want to change all the sensitive data, encrypt with vault, then commit the revised and encrypted `vault.yml` files to your repo.


### PR DESCRIPTION
roots/trellis#317

The new `vault.md` docs page might fit well after `passwords.md` in the page order. I'm guessing you'll first add the new page via the WordPress admin and then sync with this docs repo. I'll then rebase if necessary.