### PR TITLE
Trellis: Remove minor reference to Mandrill

### DIFF
--- a/trellis/mail.md
+++ b/trellis/mail.md
@@ -53,7 +53,7 @@ All of these offer around 10k+ emails for free per month. Once you have SMTP cre
 
 ### Example
 
-* `mail_smtp_server`: `smtp.mandrillapp.com:587`
+* `mail_smtp_server`: `smtp.example.com:587`
 * `mail_hostname`: `example.com`
 * `mail_user`: `admin@example.com`
 * `mail_password`: `password`


### PR DESCRIPTION
Mandrill's free tier changed a while ago and you removed it from your docs. This just removes a small reference to it in the mail docs.