### PR TITLE
Use `env` instead of `getenv`

### DIFF
--- a/trellis/multisite.md
+++ b/trellis/multisite.md
@@ -19,7 +19,7 @@ Trellis assumes your WordPress configuration already has multisite set up. If no
 define('WP_ALLOW_MULTISITE', true);
 define('MULTISITE', true);
 define('SUBDOMAIN_INSTALL', true); // Set to false if using subdirectories
-define('DOMAIN_CURRENT_SITE', getenv('DOMAIN_CURRENT_SITE'));
+define('DOMAIN_CURRENT_SITE', env('DOMAIN_CURRENT_SITE'));
 define('PATH_CURRENT_SITE', '/');
 define('SITE_ID_CURRENT_SITE', 1);
 define('BLOG_ID_CURRENT_SITE', 1);


### PR DESCRIPTION
Because of the switch to oscarotero/env