### PR TITLE
Update theme-wrapper base-*.php filter call

### DIFF
--- a/sage/theme-wrapper.md
+++ b/sage/theme-wrapper.md
@@ -149,7 +149,7 @@ Let's say you wanted your base markup to change depending on what CPT WordPress 
 
 ```php
 <?php
-  add_filter('sage/wrap_base', __NAMESPACE__ . '\sage_wrap_base_cpts'); // Add our function to the sage/wrap_base filter
+  add_filter('sage/wrap_base', __NAMESPACE__ . '\\sage_wrap_base_cpts'); // Add our function to the sage/wrap_base filter
 
   function sage_wrap_base_cpts($templates) {
     $cpt = get_post_type(); // Get the current post type


### PR DESCRIPTION
This PR adds a second backslash to match the other functions you'd find inside extras.php

There was previously one used in this file however it is not displaying [in the docs](https://roots.io/sage/docs/theme-wrapper/) and so copy pasting results in errors.

E.g. this original code:

```php
<?php
  add_filter('sage/wrap_base', __NAMESPACE__ . '\sage_wrap_base_cpts'); // Add our function to the sage/wrap_base filter

  function sage_wrap_base_cpts($templates) {
    $cpt = get_post_type(); // Get the current post type
    if ($cpt) {
       array_unshift($templates, 'base-' . $cpt . '.php'); // Shift the template to the front of the array
    }
    return $templates; // Return our modified array with base-$cpt.php at the front of the queue
  }
?>
```

is displayed on the site as:

![Image of code on website](http://i.imgur.com/qQdhIsk.png)
(with no backslashes)