### PR TITLE
Account for Vagrantfile IP configuration

### DIFF
--- a/trellis/local-development-setup.md
+++ b/trellis/local-development-setup.md
@@ -13,7 +13,8 @@ Development is handled by [Vagrant](https://www.vagrantup.com/) in Trellis. Our 
 
 1. Configure your site(s) based on the [WordPress Sites docs](https://roots.io/trellis/docs/wordpress-sites/) and read the [development specific](https://roots.io/trellis/docs/wordpress-sites/#development) ones.
 2. Make sure you've edited both `group_vars/development/wordpress_sites.yml` and `group_vars/development/vault.yml`.
-3. Run `vagrant up`.
+3. Configure the IP address at the top of the `Vagrantfile` to allow for multiple boxes to be run concurrently (default is `192.168.50.5`).
+4. Run `vagrant up`.
 
 Then let Vagrant and Ansible do their thing. After roughly 5-10 minutes you'll have a server running and a WordPress site automatically installed and configured.
 


### PR DESCRIPTION
I've run into the issue of attempting to run concurrent boxes with Trellis installations based off the initial docs. This change will account for the option to change the IP address in the Vagrantfile to allow for concurrent runs when needed and addresses it from initial setup. 