### PR TITLE
Fix typo in trellis/multisite.md.

### DIFF
--- a/trellis/multisite.md
+++ b/trellis/multisite.md
@@ -38,7 +38,7 @@ env:
   wp_siteurl: http://example.com/wp
 ```
 
-Trellis automatically sets `wp_home` and `wp_siteurl` but with multisite they needs to be manually set.
+Trellis automatically sets `wp_home` and `wp_siteurl` but with multisite they need to be manually set.
 
 ## Subdomain installs and hosts
 


### PR DESCRIPTION
This PR fixes a small typo in the multisite section of Trellis' docs.