### PR TITLE
trellis: Fix minor typos

### DIFF
--- a/trellis/debugging-php.md
+++ b/trellis/debugging-php.md
@@ -34,7 +34,7 @@ You can see all the available configuration options in `roles/xdebug/defaults/ma
 
 ## Using Xdebug in production
 
-While we default to installing Xdebug in development, installing it in any other environment is "opt-in." **It is not recommended to use Xdebug in production**, but it _can_ be extremely using in debugging production-like environments. For example, if there's an issue you're encountering in Production, but cannot reproduce in Development (aka, your Vagrant environment), it's likely the problem lies with something specific to your VPS provider. Duplicating your production environment and sanitizing the data using something like [WP Hammer](https://github.com/10up/wp-hammer) will allow you to debug your production environmment without affecting it. This is where `bin/xdebug-tunnel.sh` comes in.
+While we default to installing Xdebug in development, installing it in any other environment is "opt-in." **It is not recommended to use Xdebug in production**, but it _can_ be extremely useful in debugging production-like environments. For example, if there's an issue you're encountering in Production, but cannot reproduce in Development (aka, your Vagrant environment), it's likely the problem lies with something specific to your VPS provider. Duplicating your production environment and sanitizing the data using something like [WP Hammer](https://github.com/10up/wp-hammer) will allow you to debug your production environmment without affecting it. This is where `bin/xdebug-tunnel.sh` comes in.
 
 ### `bin/xdebug-tunnel.sh`: Xdebug + SSH tunnels
 

--- a/trellis/mail.md
+++ b/trellis/mail.md
@@ -32,7 +32,7 @@ Trellis is using the [MailHog role on Ansible Galaxy](https://galaxy.ansible.com
 
 Outgoing mail is done by the sSMTP role. sSMTP is a lightweight SMTP mail relay basically. In order to send external emails, you'll need to configure an SMTP server.
 
-We always suggest using an external email service rather than your own because it's very difficult to setup a proper email server.
+We always suggest using an external email service rather than your own because it's very difficult to set up a proper email server.
 
 Some suggested services:
 


### PR DESCRIPTION
Use two words for "set up" as a verb

-extremely using
+extremely useful

Apparently there were missing trailing newlines (at the end of the documents) so my editor automatically added them when it saved.