### PR TITLE
Sage 9 - 3rd party package's relative paths in production

### DIFF
--- a/sage/theme-development-and-building.md
+++ b/sage/theme-development-and-building.md
@@ -136,10 +136,20 @@ Example of how to add 3rd party packages* and have them included in the theme:
     // Import Slick
     @import "~slick-carousel/slick/slick.scss";
     @import "~slick-carousel/slick/slick-theme.scss";
-    ```
-
+    ```
 3. After running `yarn run build` from the theme directory, your package will be built with your theme assets. The `dist` folder will contain a `_/node_modules/` directory that has any assets referenced from your packages. The compiled CSS and JS will reference these assets without having to manually edit paths. ✨
 
+4. Running `yarn run build:production` will fail if 3rd party package's relative paths are not configured before imported. In example to load Slick Carousel's paths add the following line in your common/_variables.scss file:
+
+  ``scss
+  /* sage/assets/styles/common/_variables.scss */
+  // Slick Carousel font path
+	$slick-font-path: "~slick-carousel/slick/fonts/" !default;
+		
+  // Slick Carousel ajax-loader.gif path
+  $slick-loader-path: "~slick-carousel/slick/" !default;
+  
+  
 <small>&lowast;Note: Wordpress Plugins are installed elsewhere or with Composer when using [Bedrock](/bedrock/docs/composer)</small>
 
 ### Additional examples

--- a/sage/theme-development-and-building.md
+++ b/sage/theme-development-and-building.md
@@ -141,14 +141,14 @@ Example of how to add 3rd party packages* and have them included in the theme:
 
 4. Running `yarn run build:production` will fail if 3rd party package's relative paths are not configured before imported. In example to load Slick Carousel's paths add the following line in your common/_variables.scss file:
 
-  ``scss
+  ```scss
   /* sage/assets/styles/common/_variables.scss */
   // Slick Carousel font path
 	$slick-font-path: "~slick-carousel/slick/fonts/" !default;
 		
   // Slick Carousel ajax-loader.gif path
   $slick-loader-path: "~slick-carousel/slick/" !default;
-  
+  ```
   
 <small>&lowast;Note: Wordpress Plugins are installed elsewhere or with Composer when using [Bedrock](/bedrock/docs/composer)</small>
 

--- a/sage/theme-development-and-building.md
+++ b/sage/theme-development-and-building.md
@@ -136,19 +136,20 @@ Example of how to add 3rd party packages* and have them included in the theme:
     // Import Slick
     @import "~slick-carousel/slick/slick.scss";
     @import "~slick-carousel/slick/slick-theme.scss";
-    ```
+    ```
+    
 3. After running `yarn run build` from the theme directory, your package will be built with your theme assets. The `dist` folder will contain a `_/node_modules/` directory that has any assets referenced from your packages. The compiled CSS and JS will reference these assets without having to manually edit paths. ✨
 
 4. Running `yarn run build:production` will fail if 3rd party package's relative paths are not configured before imported. In example to load Slick Carousel's paths add the following line in your common/_variables.scss file:
 
-  ```scss
-  /* sage/assets/styles/common/_variables.scss */
-  // Slick Carousel font path
-	$slick-font-path: "~slick-carousel/slick/fonts/" !default;
+    ```scss
+    /* sage/assets/styles/common/_variables.scss */
+    // Slick Carousel font path
+    $slick-font-path: "~slick-carousel/slick/fonts/";
 		
-  // Slick Carousel ajax-loader.gif path
-  $slick-loader-path: "~slick-carousel/slick/" !default;
-  ```
+    // Slick Carousel ajax-loader.gif path
+    $slick-loader-path: "~slick-carousel/slick/";
+    ```
   
 <small>&lowast;Note: Wordpress Plugins are installed elsewhere or with Composer when using [Bedrock](/bedrock/docs/composer)</small>
 


### PR DESCRIPTION
Added 4th step how to configure font paths for 3rd party packages. Example uses the Slick Slider. In short you must configure path before importing the package. And remember to use "~" to tell Webpack to locate these files from node_modules folder:

`$slick-font-path: "~slick-carousel/slick/fonts/" !default;`

In Slick Slider you have to configure path for the ajax-loader.gif:
`$slick-loader-path: "~slick-carousel/slick/" !default;`