### PR TITLE
Trellis: Add SSH connections section to troubleshooting docs

### DIFF
--- a/trellis/security.md
+++ b/trellis/security.md
@@ -10,7 +10,7 @@ published: true
 ---
 ## Locking down root
 
-The `sshd` role heightens your server's security by providing better SSH defaults. SSH password authentication will be disabled. We encourage you to disable SSH `root` login as well. You may adjust these two particular options in `group_vars/all/security.yml`.
+The `sshd` role heightens your server's security by providing better SSH defaults. SSH password authentication will be disabled. We encourage you to disable SSH `root` login as well. You may adjust these two particular options in `group_vars/all/security.yml`. See the [`sshd` role `README.md`](https://github.com/roots/trellis/tree/master/roles/sshd) for more configuration options.
 
 ## Admin user
 

--- a/trellis/ssh-keys.md
+++ b/trellis/ssh-keys.md
@@ -41,7 +41,7 @@ Each Trellis playbook uses a specific SSH user to connect to your remote machine
   </tbody>
 </table>
 
-This wiki reviews how to configure SSH users for the `server.yml` and `deploy.yml` playbooks.
+This page reviews how to configure SSH users for the `server.yml` and `deploy.yml` playbooks. If you are looking for general SSH configuration options, see the [`sshd` role `README.md`](https://github.com/roots/trellis/tree/master/roles/sshd) .
 
 If you will be the only person provisioning and deploying, and your SSH public key is available at `~/.ssh/id_rsa.pub`, you will probably not need to modify the Trellis defaults for `users`.
 
@@ -65,7 +65,7 @@ If needed, you may redefine the `users` in any given `group_vars` environment fi
 ## `server.yml`: `root` or `admin`
 We assume that when you first create your server you've already added your SSH key to the `root` account. Digital Ocean will add this for you when you create a droplet. If you don't want to use an SSH key, you will need to add the `--ask-pass` option each time you run the `server.yml` playbook.
 
-`server.yml` will try to connect to your server as `root`. If the connection fails, `server.yml` will try to connect as the `admin_user` defined in `group_vars/all/users.yml` (default `admin`). If `root` login will be disabled on your server, it is critical for the `admin_user` to be defined in your list of `users`, with `sudo` first in this user's list of groups (see the [Security wiki](https://github.com/roots/trellis/wiki/Security)). The default definition for the `admin_user` is shown below.
+`server.yml` will try to connect to your server as `root`. If the connection fails, `server.yml` will try to connect as the `admin_user` defined in `group_vars/all/users.yml` (default `admin`). If `root` login will be disabled on your server, it is critical for the `admin_user` to be defined in your list of `users`, with `sudo` first in this user's list of groups (see the [Security docs](https://roots.io/trellis/docs/security/)). The default definition for the `admin_user` is shown below.
 
 ```yaml
 users:
@@ -105,7 +105,7 @@ You may enable colleagues to run `deploy.yml` by adding their public SSH `keys` 
 
 ## Example `users`
 
-The example below adds the SSH keys of GitHub users `swalkinshaw` and `retlehs` to `~/.ssh/authorized_keys` for `admin_user`. This enables `swalkinshaw` and `retlehs` to run `server.yml` to provision the servers. The example also adds their keys, and the keys of of GitHub user `austinpray`, to `web_user`. This enables each of them to run `deploy.yml` to deploy sites. 
+The example below adds the SSH keys of GitHub users `swalkinshaw` and `retlehs` to `~/.ssh/authorized_keys` for `admin_user`. This enables `swalkinshaw` and `retlehs` to run `server.yml` to provision the servers. The example also adds their keys, and the keys of GitHub user `austinpray`, to `web_user`. This enables each of them to run `deploy.yml` to deploy sites.
 
 ```yaml
 users:

--- a/trellis/troubleshooting.md
+++ b/trellis/troubleshooting.md
@@ -22,7 +22,7 @@ Example: if a Git clone task failed during deploys, then SSH into the server as 
 
 <hr>
 
-### Unresponsive machines or 404s
+## Unresponsive machines or 404s
 
 Halt all VMs and remove VM-related entries from your `/etc/hosts` file, particularly entries similar to the example below. You may want to backup the hosts file before editing.
 
@@ -36,7 +36,7 @@ A tidy hosts file would reduce the likelihood of 404s, although it's not a guara
 
 <hr>
 
-### Sequel Pro permission denied error
+## Sequel Pro permission denied error
 
 Are you getting `Permission denied (publickey)` when trying to connect to your Vagrant box with Sequel Pro?
 
@@ -44,13 +44,13 @@ Use the insecure private key inside the `.vagrant` folder. [See thread on Roots 
 
 <hr>
 
-### Let's Encrypt SSL Certificates
+## Let's Encrypt SSL certificates
 
 See [Troubleshooting Let's Encrypt](https://roots.io/trellis/docs/ssl/#troubleshooting-lets-encrypt).
 
 <hr>
 
-### There was an error while executing `VBoxManage`, a CLI used by Vagrant
+## There was an error while executing `VBoxManage`, a CLI used by Vagrant
 
 Error message looks something like:
 
@@ -66,6 +66,100 @@ The solution is to open up your Activity Monitor and quit any `vagrant` or `ruby
 
 <hr>
 
-### Composer install: host key verification failed
+## Composer install: host key verification failed
 
 Sometimes a task that installs Composer dependencies gives an error `host key verification failed`. This can happen when the `known_hosts` file on your Vagrant VM or remote host is missing a key for one of the host `repositories` in the related `composer.json` file. Ensure that each host from `composer.json` has a key listed in `group_vars/all/known_hosts.yml` then try your `vagrant provision` or `./bin/deploy.sh` command again.
+
+<hr>
+
+## SSH connections
+
+If you have trouble with SSH connections to your server, consider the tips below. You may also want to review information about [disabling `root` login](https://roots.io/trellis/docs/security/#locking-down-root) and how to configure your server's SSH settings via the [`sshd` role](https://github.com/roots/trellis/tree/master/roles/sshd).
+
+### SSH keys
+
+* [Generating a new SSH key and adding it to the ssh-agent](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
+* [Testing your SSH connection](https://help.github.com/articles/testing-your-ssh-connection/)
+* [Your local `ssh-agent` must be running](https://developer.github.com/guides/using-ssh-agent-forwarding/#your-local-ssh-agent-must-be-running) (macOS users: remember to run `ssh-add -K`)
+* How to designate [SSH keys](https://roots.io/trellis/docs/ssh-keys/) in Trellis
+
+SSH will automatically look for and try a default set of SSH keys, along with keys loaded in your `ssh-agent`. However, the SSH server will only let your SSH client try a limited number of keys before disconnecting (default: 6). If you have many SSH keys and the correct key is not being selected, you can force your SSH client to try only the correct key. Add this to your `~/.ssh/config` (with the correct path to your key):
+
+```
+Host example.com
+  IdentitiesOnly yes
+  IdentityFile /users/username/.ssh/id_rsa
+```
+
+### Host key change
+
+Your server may occasionally offer a different host key than what your local machine has on record in `known_hosts`. This could happen if you rebuild your server or if the `sshd` role configures your server to offer a stronger key.
+
+Example 1
+
+```
+TASK [setup] *******************************************************************
+System info:
+  Ansible 2.2.1.0; Darwin
+  Trellis at "Add `apt_packages_custom` to customize Apt packages"
+---------------------------------------------------
+SSH Error: data could not be sent to the remote host. Make sure this host can
+be reached over ssh
+fatal: [xxx.xxx.xxx.xxx]: UNREACHABLE! => {"changed": false, "unreachable": true}
+    to retry, use: --limit @/Users/yourname/sites/example.com/trellis/deploy.retry
+```
+
+Example 2
+
+```
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
+Someone could be eavesdropping on you right now (man-in-the-middle attack)!
+It is also possible that a host key has just been changed.
+The fingerprint for the ED25519 key sent by the remote host is
+SHA256:lv86hFykjn8pnOWE2WDWJo8Mzf6FTDMx/yWXOqzK5PU.
+```
+
+If this change in host keys is expected, then clear the old host key from your `known_hosts` by running the following command (with your real IP or host name).
+
+```
+  ssh-keygen -R 12.34.56.78
+```
+
+Then try your Trellis playbook or SSH connection again.
+
+If the host key change is unexpected, cautiously consider why the host identification may have changed and whether you may be victim to a man-in-the-middle attack.
+
+### `git clone` or `composer install` task hangs or fails
+
+The `sshd` role may cause your server's SSH client to request stronger host keys from hosts of git repos or composer packages. This could create the [host-key-change](#host-key-change) problem, but this time on your server instead of your local machine. Follow the same remediation steps, but on the server.
+
+Similarly, the `sshd` role may cause your server's SSH client to require stronger [ciphers, kex algorithms, and MACs](https://github.com/roots/trellis/tree/master/roles/sshd#ciphers-kexalgorithms-and-macs) than previously. If your `git clone` or `composer install` connections involve older systems that do not support the stronger protocols, you may need to add more options to `ssh_ciphers_extra`, `ssh_kex_algorithms_extra`, or `ssh_macs_extra`.
+
+### Verbose output
+
+SSH connection issues are often difficult to resolve without verbose output. Use the `-vvvv` option with your `ansible-playbook` command:
+
+```
+ansible-playbook server.yml -e env=production -vvvv
+```
+
+You may also use `-v`, `-vv`, and `-vvv` with manual SSH connections:
+
+```
+ssh -v root@12.34.56.78
+```
+
+### Manual SSH
+
+If your `ansible-playbook` command is failing its SSH connection, it can be helpful to try a manual SSH connection to narrow down the problem. If manual SSH fails, try again with `-v` for [verbose output](#verbose-output).
+
+```
+ssh -v root@12.34.56.78
+```
+
+### `Ciphers`, `KexAlgorithms`, or `MACs`
+
+The `sshd` role will most likely cause your SSH server to discontinue using some older and weaker protocols. If your connections involve older systems that do not support the stronger protocols configured by the `sshd` role, see [`Ciphers`, `KexAlgorithms`, and `MACs`](https://github.com/roots/trellis/tree/master/roles/sshd#ciphers-kexalgorithms-and-macs) for how to add back in any protocols you need.


### PR DESCRIPTION
Transfers "Troubleshooting" text from roots/trellis#744's README to the Trellis troubleshooting docs.  

