### PR TITLE
Add the clone step

### DIFF
--- a/bedrock/installing-bedrock.md
+++ b/bedrock/installing-bedrock.md
@@ -16,8 +16,9 @@ published: true
 
 ## Installation
 
-1. Create a new project - `composer create-project roots/bedrock`
-2. Copy `.env.example` to `.env` and update environment variables:
+1. Clone the [bedrock repository](https://github.com/roots/bedrock/) `git clone https://github.com/roots/bedrock.git`
+1. Enter in the cloned repo and run via command `composer install`
+1. Copy `.env.example` to `.env` and update environment variables:
   * `DB_NAME` - Database name
   * `DB_USER` - Database user
   * `DB_PASSWORD` - Database password


### PR DESCRIPTION
When installing we should say that the first thing is to clone as said here https://discourse.roots.io/t/missing-step-installing-bedrock/5542 
If we don't say it the .env.example will be missing