### PR TITLE
Consistency required

### DIFF
--- a/trellis/multisite.md
+++ b/trellis/multisite.md
@@ -14,7 +14,7 @@ Trellis assumes your WordPress configuration already has multisite set up. If no
 /* Multisite */
 define('WP_ALLOW_MULTISITE', true);
 define('MULTISITE', true);
-define('SUBDOMAIN_INSTALL', true); // Set to false if using subdirectories
+define('SUBDOMAIN_INSTALL', false); // Set to true if using subdirectories
 define('DOMAIN_CURRENT_SITE', env('DOMAIN_CURRENT_SITE'));
 define('PATH_CURRENT_SITE', env('PATH_CURRENT_SITE') ?: '/');
 define('SITE_ID_CURRENT_SITE', env('SITE_ID_CURRENT_SITE') ?: 1);


### PR DESCRIPTION
The example code for application.php has 'subdomain install: true' but the wordpress_sites.yml example code has subdomains: false

I think we should pick one.