### PR TITLE
Fix SUBDOMAIN_INSTALL code comment

### DIFF
--- a/trellis/multisite.md
+++ b/trellis/multisite.md
@@ -14,7 +14,7 @@ Trellis assumes your WordPress configuration already has multisite set up. If no
 /* Multisite */
 define('WP_ALLOW_MULTISITE', true);
 define('MULTISITE', true);
-define('SUBDOMAIN_INSTALL', false); // Set to true if using subdirectories
+define('SUBDOMAIN_INSTALL', false); // Set to true if using subdomains
 define('DOMAIN_CURRENT_SITE', env('DOMAIN_CURRENT_SITE'));
 define('PATH_CURRENT_SITE', env('PATH_CURRENT_SITE') ?: '/');
 define('SITE_ID_CURRENT_SITE', env('SITE_ID_CURRENT_SITE') ?: 1);


### PR DESCRIPTION
The comment next to `define('SUBDOMAIN_INSTALL', false);` in the Multisite docs says that the define should be set to `true` for subdirectories. This should read "subdomains", and this PR fixes that.