### PR TITLE
Refer to the new vagrant config yml file

### DIFF
--- a/trellis/local-development-setup.md
+++ b/trellis/local-development-setup.md
@@ -13,7 +13,7 @@ Development is handled by [Vagrant](https://www.vagrantup.com/) in Trellis. Our 
 
 1. Configure your site(s) based on the [WordPress Sites docs](https://roots.io/trellis/docs/wordpress-sites/) and read the [development specific](https://roots.io/trellis/docs/wordpress-sites/#development) ones.
 2. Make sure you've edited both `group_vars/development/wordpress_sites.yml` and `group_vars/development/vault.yml`.
-3. Optionally configure the IP address at the top of the `Vagrantfile` to allow for multiple boxes to be run concurrently (default is `192.168.50.5`).
+3. Optionally configure the IP address at the top of the `vagrant.default.yml` to allow for multiple boxes to be run concurrently (default is `192.168.50.5`).
 4. Run `vagrant up` (from your trellis directory, usually the `trellis/` subdirectory of your project).
 
 Then let Vagrant and Ansible do their thing. After roughly 5-10 minutes you'll have a server running and a WordPress site automatically installed and configured.


### PR DESCRIPTION
I saw that the config for the Vagrant has been refactored to the vagrant.default.yml file. Updating the docs to reflect this change.