### PR TITLE
Make a note about "all" folder in includes.d

### DIFF
--- a/trellis/nginx-includes.md
+++ b/trellis/nginx-includes.md
@@ -40,6 +40,15 @@ trellis/
       rewrites.conf.j2
 ```
 
+You could also have an "all" directory, which would apply conf to all sites:
+
+```
+trellis/
+  nginx-includes/
+    all/
+      rewrites.conf.j2
+```
+
 The above directory structure would be templated to the remote server as follows:
 
 ```


### PR DESCRIPTION
Note for https://github.com/roots/trellis/pull/966 

Sidenote: 
Thoughts on putting a suggestion to setup a project-template in the docs and/or Trellis readme? It would make the all folder more understandable for it's purpose.

Examples:
- https://github.com/partounian/trellis
- https://github.com/TangRufus/trellis/tree/project-template

Also I can improve the instructions here on repo setup, trellis best practices  and add it somewhere if you like. I have had great success setting up multiple repos with one upstream each, in fact it's very straightforward and more understandable then the whole subtree idea.

@TangRufus @swalkinshaw @retlehs 
Sorry if I missed an @ for someone