### PR TITLE
Update Sage theme structure to latest

### DIFF
--- a/sage/theme-configuration-and-setup.md
+++ b/sage/theme-configuration-and-setup.md
@@ -70,7 +70,7 @@ Sage registers two sidebars by default: Primary & Footer. Add additional sidebar
 ```shell
 themes/your-theme-name/   # → Root of your Sage based theme
 ├── app/                  # → Theme PHP
-│   ├── lib/Sage/         # → Blade implementation, asset manifest
+│   ├── controllers/      # → Controller files
 │   ├── admin.php         # → Theme customizer setup
 │   ├── filters.php       # → Theme filters
 │   ├── helpers.php       # → Helper functions
@@ -88,7 +88,6 @@ themes/your-theme-name/   # → Root of your Sage based theme
 │   │   ├── images/       # → Theme images
 │   │   ├── scripts/      # → Theme JS
 │   │   └── styles/       # → Theme stylesheets
-│   ├── controllers/      # → Controller files
 │   ├── functions.php     # → Composer autoloader, theme includes
 │   ├── index.php         # → Never manually edit
 │   ├── screenshot.png    # → Theme screenshot for WP admin


### PR DESCRIPTION
https://discourse.roots.io/t/confused-about-file-structe/12095

- Moved `controllers/` to `app/`
- Removed `lib/Sage/`

I guess the top level `config` directory is missing as well, both here and in [Sage’s README](https://github.com/roots/sage/blob/master/README.md#theme-structure). I didn’t add it because I couldn’t think a description for it. "Paths to stuff" probably won’t suffice.