### PR TITLE
Escape quotes and notice about gettext

### DIFF
--- a/sage/theme-localization.md
+++ b/sage/theme-localization.md
@@ -18,11 +18,11 @@ post_date: 2018-04-24 10:47:48
       ...
       "scripts": {
         ...
-        "pot": "mkdir -p ./resources/lang && find ./resources ./app -iname \"*.php\" | xargs xgettext --add-comments=TRANSLATORS --force-po --from-code=UTF-8 --default-domain=de_DE -k__ -k_e -k_n:1,2 -k_x:1,2c -k_ex:1,2c -k_nx:4c,12 -kesc_attr__ -kesc_attr_e -kesc_attr_x:1,2c -kesc_html__ -kesc_html_e -kesc_html_x:1,2c -k_n_noop:1,2 -k_nx_noop:3c,1,2, -k__ngettext_noop:1,2 -o resources/lang/sage.pot && find ./resources -iname '*.blade.php' | xargs xgettext --language=Python --add-comments=TRANSLATORS --force-po --from-code=UTF-8 --default-domain=de_DE -k__ -k_e -k_n:1,2 -k_x:1,2c -k_ex:1,2c -k_nx:4c,12 -kesc_attr__ -kesc_attr_e -kesc_attr_x:1,2c -kesc_html__ -kesc_html_e -kesc_html_x:1,2c -k_n_noop:1,2 -k_nx_noop:3c,1,2, -k__ngettext_noop:1,2 -j -o resources/lang/sage.pot"
+        "pot": "mkdir -p ./resources/lang && find ./resources ./app -iname '*.php' | xargs xgettext --add-comments=TRANSLATORS --force-po --from-code=UTF-8 --default-domain=de_DE -k__ -k_e -k_n:1,2 -k_x:1,2c -k_ex:1,2c -k_nx:4c,12 -kesc_attr__ -kesc_attr_e -kesc_attr_x:1,2c -kesc_html__ -kesc_html_e -kesc_html_x:1,2c -k_n_noop:1,2 -k_nx_noop:3c,1,2, -k__ngettext_noop:1,2 -o resources/lang/sage.pot && find ./resources -iname '*.blade.php' | xargs xgettext --language=Python --add-comments=TRANSLATORS --force-po --from-code=UTF-8 --default-domain=de_DE -k__ -k_e -k_n:1,2 -k_x:1,2c -k_ex:1,2c -k_nx:4c,12 -kesc_attr__ -kesc_attr_e -kesc_attr_x:1,2c -kesc_html__ -kesc_html_e -kesc_html_x:1,2c -k_n_noop:1,2 -k_nx_noop:3c,1,2, -k__ngettext_noop:1,2 -j -o resources/lang/sage.pot"
       },
     }
     ```
-2. Run `yarn pot` from your theme directory to generate the language files
+2. Run `yarn pot` from your theme directory to generate the language files. In case of an error, install/update `coreutils`, `findutils`and/or `gettext` on homebrew.
 3. Open the generated `.pot` file with Poedit, select "Create new translation", save `.mo` & `.po` files in the `resources/lang` folder with the correct name syntax (eg. `fr_FR`, `en_US`)
 
 When adding/removing translations in templates, run `yarn pot` again, then select "Catalog > Update from a POT file" in Poedit.


### PR DESCRIPTION
Changed to single quotes on line 21: '*.php' and added a notice that in case of errors, coreutils, findutils and/or gettext should be updated/installed with homebrew, as talked about here: https://discourse.roots.io/t/theme-localization-problem-with-yarn-pot/12410

(This is my first time providing a pull request, please don't hesitate to give me feedback what I could do better next time. I tried to follow the guidelines on github.)