### PR TITLE
Fixed typo (space after findutils)

### DIFF
--- a/sage/theme-localization.md
+++ b/sage/theme-localization.md
@@ -22,7 +22,7 @@ post_date: 2018-04-24 10:47:48
       },
     }
     ```
-2. Run `yarn pot` from your theme directory to generate the language files. In case of an error, install/update `coreutils`, `findutils`and/or `gettext` on homebrew.
+2. Run `yarn pot` from your theme directory to generate the language files. In case of an error, install/update `coreutils`, `findutils` and/or `gettext` on homebrew.
 3. Open the generated `.pot` file with Poedit, select "Create new translation", save `.mo` & `.po` files in the `resources/lang` folder with the correct name syntax (eg. `fr_FR`, `en_US`)
 
 When adding/removing translations in templates, run `yarn pot` again, then select "Catalog > Update from a POT file" in Poedit.


### PR DESCRIPTION
Fixed typo (space after `findutils`)