### PR TITLE
Change suggestion for git encryption tool

### DIFF
--- a/trellis/passwords.md
+++ b/trellis/passwords.md
@@ -23,6 +23,6 @@ There are a few places you'll want to set/change passwords:
 
 For staging/production environments, it's best to randomly generate longer passwords using something like [random.org](http://www.random.org/passwords/).
 
-You may be concerned about setting plaintext passwords in a Git repository, and you should be. We strongly recommend you encrypt these passwords before committing them to your repo. Trellis is structured to make it easy to enable [Ansible Vault](https://roots.io/trellis/docs/vault/) to encrypt select files. Alternatively, you could try an option such as [Git Encrypt](https://github.com/shadowhand/git-encrypt).
+You may be concerned about setting plaintext passwords in a Git repository, and you should be. We strongly recommend you encrypt these passwords before committing them to your repo. Trellis is structured to make it easy to enable [Ansible Vault](https://roots.io/trellis/docs/vault/) to encrypt select files. Alternatively, you could try an option such as [git-crypt](https://github.com/AGWA/git-crypt).
 
 Note: Any type of server configs such as this playbook should always be in a **private** Git repository.


### PR DESCRIPTION
Git Encrypt is deprecated and no longer maintained, so it makes sense to switch to the tool its former maintainer recommends switching to.