### PR TITLE
Update macOS yarn installation command

### DIFF
--- a/getting-started/macos-development-environment-sage.md
+++ b/getting-started/macos-development-environment-sage.md
@@ -36,5 +36,5 @@ $ nvm install --lts
 Install yarn from Homebrew:
 
 ```sh
-$ brew install yarn --without-node
+$ brew install yarn --ignore-dependencies
 ```


### PR DESCRIPTION
Options are no longer a thing for Homebrew formulae. This does the same thing though.