### PR TITLE
Update windows-development-environment-trellis.md

### DIFF
--- a/getting-started/windows-development-environment-trellis.md
+++ b/getting-started/windows-development-environment-trellis.md
@@ -29,8 +29,8 @@ Then alias `vagrant` in WSL to `vagrant.exe`:
 **⚠️ The following commands must be run from WSL ([Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)).**
 
 ```sh
-$ echo 'alias vagrant=vagrant.exe' >> ~/.bashrc
-$ source ~/.bashrc
+$ echo 'alias vagrant=vagrant.exe' >> ~/.zshrc
+$ source ~/.zshrc
 ```
 
 ## Ansible


### PR DESCRIPTION
WSL Ubuntu uses .zshrc and not .bashrc. 

I don't understand it all but if you run vagrant you will get 'command not found'.

My change means that you can use vagrant commands in WSL