### PR TITLE
add sudo apt install php-zip

### DIFF
--- a/getting-started/windows-basic-setup.md
+++ b/getting-started/windows-basic-setup.md
@@ -34,7 +34,7 @@ Install PHP 7.3:
 ```sh
 $ sudo add-apt-repository ppa:ondrej/php
 $ sudo apt-get update
-$ sudo apt-get install php7.3 php7.3-mbstring php7.3-xml
+$ sudo apt-get install php7.3 php7.3-mbstring php7.3-xml php-zip
 ```
 
 ## Composer


### PR DESCRIPTION
There was a post on discourse recently about missing php-zip at Windows Setup Guide: https://discourse.roots.io/t/getting-started-document-php-zip/17116/2

I went through my notes and found I had the same issue as well (I am WSL user). I also fixed it by running "sudo apt-get install php-zip".