### PR TITLE
Specific `php-zip` PHP version number

### DIFF
--- a/getting-started/windows-basic-setup.md
+++ b/getting-started/windows-basic-setup.md
@@ -34,7 +34,7 @@ Install PHP 7.3:
 ```sh
 $ sudo add-apt-repository ppa:ondrej/php
 $ sudo apt-get update
-$ sudo apt-get install php7.3 php7.3-mbstring php7.3-xml php-zip
+$ sudo apt-get install php7.3 php7.3-mbstring php7.3-xml php7.3-zip
 ```
 
 ## Composer


### PR DESCRIPTION
In case `ppa:ondrej/php` _alias_ `php-zip` to `php7.4-zip` when PHP 7.4 is released.