### PR TITLE
Add Xilonz's extensions to Trellis user-contributed-extensions.md

### DIFF
--- a/docs/trellis/master/user-contributed-extensions.md
+++ b/docs/trellis/master/user-contributed-extensions.md
@@ -10,8 +10,10 @@ Issues with extensions should be opened in their respective repositories.
 
 - [bedrock-site-protect](https://github.com/louim/bedrock-site-protect) — Add or remove htpasswd protection to your websites
 - [trellis-backup](https://discourse.roots.io/t/trellis-backup-an-ansible-role-for-local-backups/6497) — Set up automated backups to various locations using duplicity.
+- [trellis-backup](https://github.com/Xilonz/trellis-backup-role) — Set up automated backups to various locations using duply.
 - [trellis-cloudflare-origin-ca](https://typist.tech/portfolio-item/trellis-cloudflare-origin-ca/) — Add Cloudflare Origin CA to Trellis as SSL provider.
 - [trellis-newrelic-php](https://typist.tech/portfolio-item/trellis-newrelic-php/) — Install New Relic PHP agent on Trellis servers
+- [trellis-nixstats](https://github.com/Xilonz/trellis-nixstats/) — Install NIXStats agent on Trellis servers
 - [trellis-database-uploads-migration](https://github.com/valentinocossar/trellis-database-uploads-migration) — Ansible playbook for Trellis that manages database and uploads migration
 - [trellis-db-push-and-pull](https://github.com/hamedb89/trellis-db-push-and-pull) — Push and pull databases with Trellis and Ansible playbooks
 - [trellis-backup-during-deploy](https://github.com/ItinerisLtd/trellis-backup-during-deploy) - Backup WordPress database during Trellis deploys


### PR DESCRIPTION
I've taken over the jillro/trellis-backup-role repo and brought is back to life. Also took the opportunity to add my NIXStats role in here :)
The 2 backup roles are quite similar, but (Xilonz/trellis-backup-role )[https://github.com/Xilonz/trellis-backup-role] is a bit more configurable and soon™ will have some nice QoL updates.