### PR TITLE
Fix nginx location modifiers

### DIFF
--- a/docs/bedrock/master/server-configuration.md
+++ b/docs/bedrock/master/server-configuration.md
@@ -19,7 +19,7 @@ server {
   index index.php index.htm index.html;
 
   # Prevent PHP scripts from being executed inside the uploads folder.
-  location ~- /app/uploads/.*.php$ {
+  location ~* /app/uploads/.*.php$ {
     deny all;
   }
 

--- a/docs/sage/9.x/installation.md
+++ b/docs/sage/9.x/installation.md
@@ -56,19 +56,19 @@ Sage uses [composer](https://getcomposer.org/) and [yarn](https://yarnpkg.com) t
 Add to your server block before the final location directive:
 
 ```
-location ~- \.(blade\.php)$ {
+location ~* \.(blade\.php)$ {
   deny all;
 }
 
-location ~- composer\.(json|lock)$ {
+location ~* composer\.(json|lock)$ {
   deny all;
 }
 
-location ~- package(-lock)?\.json$ {
+location ~* package(-lock)?\.json$ {
   deny all;
 }
 
-location ~- yarn\.lock$ {
+location ~* yarn\.lock$ {
   deny all;
 }
 ```


### PR DESCRIPTION
The examples use `~-` which is not supported by nginx. It should be `~*`.

http://nginx.org/en/docs/http/ngx_http_core_module.html#location

Looks like these code examples were changed during the conversion to VuePress.