### PR TITLE
Fix path to uploads import directory

### DIFF
--- a/docs/trellis/master/existing-projects.md
+++ b/docs/trellis/master/existing-projects.md
@@ -108,4 +108,4 @@ $ wp search-replace http://example.com http://example.test
 
 ## Import the Uploads
 
-Retrieve a copy of the current project’s `uploads` directory and place it in your local project's `site/app` directory.
+Retrieve a copy of the current project’s `uploads` directory and place it in your local project's `site/web/app` directory.


### PR DESCRIPTION
The documentation wrongly states that when importing the `uploads` directory from an existing WordPress project to Trellis, the copy should be placed in the `site/app` directory, which is not a standard Treillis/Bedrock path.

This pull request changes the path to the proper `site/web/app` location.