### PR TITLE
Updated to specify WSL 1

### DIFF
--- a/docs/getting-started/windows.md
+++ b/docs/getting-started/windows.md
@@ -1,9 +1,9 @@
-# Windows (WSL)
+# Windows (WSL 1)
 
 Trellis, Bedrock, and Sage development on Windows is supported by several libraries and software packages. 
 
 ::: warning Note
-**All commands must be run from WSL ([Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)).**
+**All commands must be run from WSL 1 ([Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)).**
 :::
 
 ## Global Dependencies


### PR DESCRIPTION
Vagrant doesn't work with WSL 2 just yet, specifically shared folders.