### PR TITLE
Clarify the installation of Trellis

### DIFF
--- a/docs/trellis/master/installation.md
+++ b/docs/trellis/master/installation.md
@@ -45,7 +45,7 @@ $ mkdir example.com && cd example.com
 ```bash
 $ git clone --depth=1 git@github.com:roots/trellis.git && rm -rf trellis/.git
 ```
-3. Install Bedrock into the `site` directory:
+3. Install Bedrock into the `site` directory outside of the trellis folder:
 ```bash
 $ composer create-project roots/bedrock site
 ```


### PR DESCRIPTION
I'm guessing the site folder has to be outside the trellis folder we just cloned. There needs to be more clarity on this for first time users.