### PR TITLE
Basic docs for 10 review

### DIFF
--- a/docs/sage/10.x/compatibility.md
+++ b/docs/sage/10.x/compatibility.md
@@ -7,8 +7,8 @@ description: A list of currently known compatibility issues with any WordPress p
 ## Adding support for plugins
 
 - No current official support for WooCommerce, but there are a number of options from the community that may be helpful:
-    - https://github.com/ptrckvzn/sage-woocommerce
-    - https://github.com/generoi/sage-woocommerce
+    - [https://github.com/ptrckvzn/sage-woocommerce](https://github.com/ptrckvzn/sage-woocommerce)
+    - [https://github.com/generoi/sage-woocommerce](https://github.com/ptrckvzn/sage-woocommerce)
     
 
 ## Known issues with plugins

--- a/docs/sage/10.x/error-handling.md
+++ b/docs/sage/10.x/error-handling.md
@@ -12,7 +12,7 @@ The `debug` opion in your `config/app.php` is solely responsible for whether or 
 
 During local development, it is highly advised to ensure this variable is set to `true` to properly render exceptions thrown by Blade views and other errors further down the stack.
 
-::: caution Warning
+::: warning Warning
 This should be set to `false` during production.
 :::
 

--- a/docs/sage/10.x/functionality.md
+++ b/docs/sage/10.x/functionality.md
@@ -22,7 +22,7 @@ The PHP code in Sage is [namespaced](https://roots.io/namespacing-and-autoloadin
 - `app/helpers.php` – A place for you to put functions used throughout your theme.
     Does not ship with any code.
 
-- `app/Providers` - The place for any [Service Providers](https://laravel.com/docs/7.x/providers) you care to define for your theme.
+- `app/Providers` - The place for any [Service Providers](https://laravel.com/docs/8.x/providers) you care to define for your theme.
     Comes with `ThemeServiceProvider` that adds no functionality but provides a template for your own Service Providers.
     
 - `app/View` - The place for view-related code, i.e. Composers and Components.

--- a/docs/sage/10.x/localization.md
+++ b/docs/sage/10.x/localization.md
@@ -20,7 +20,7 @@ description: How to generate language files for your WordPress theme created wit
 
 2. Run `yarn pot` from your theme directory to generate the language files. In case of an error, install/update `coreutils`, `findutils` and/or `gettext` on homebrew.
 
-3. Open the generated `.pot` file with Poedit, select "Create new translation", save `.mo` & `.po` files in the `resources/lang` folder with the correct name syntax (eg. `fr_FR`, `en_US`)
+3. Open the generated `.pot` file with [Poedit](https://poedit.net/), select "Create new translation", save `.mo` & `.po` files in the `resources/lang` folder with the correct name syntax (eg. `fr_FR`, `en_US`)
 
 When adding/removing translations in templates, run `yarn pot` again, then select "Catalog > Update from a POT file" in Poedit.
 

--- a/docs/sage/10.x/sidebar.md
+++ b/docs/sage/10.x/sidebar.md
@@ -18,4 +18,4 @@ For example:
 @endsection
 ```
 
-For more information on how to use sections, see the [Blade documentation](https://laravel.com/docs/7.x/blade).
+For more information on how to use sections, see the [Blade documentation](https://laravel.com/docs/8.x/blade).

--- a/docs/sage/10.x/structure.md
+++ b/docs/sage/10.x/structure.md
@@ -60,7 +60,7 @@ The `app` directory contains the core code and functionality of your theme. Almo
 
 ### The Config Directory
 
-The `config` directory contains configuration pertaining directly to Sage and it's functionality with Acorn. Here you will not find much confugration related to WordPress but instead configuration for things such as modifying Blade view paths, registering directives, changing the asset path, and configuration for packages built for Sage.
+The `config` directory contains configuration pertaining directly to Sage and it's functionality with Acorn. Here you will not find much configration related to WordPress but instead configuration for things such as modifying Blade view paths, registering directives, changing the asset path, and configuration for packages built for Sage.
 
 ### The Dist Directory
 
@@ -68,10 +68,10 @@ The `dist` directory contains the compiled assets for your theme. This directory
 
 ### The Node Modules Directory
 
-The `node_modules` directory contains your [Node](#) dependencies used to build your assets during development or for production. This folder is automatically generated and should not be modified.
+The `node_modules` directory contains your [Node](https://nodejs.org/) dependencies used to build your assets during development or for production. This folder is automatically generated and should not be modified.
 
 ::: danger Do Not Upload
-Not under any circumstance should there ever be a need to upload this folder or any of it's contents to a live production server. Not only is it a huge waste of time, it is a security risk.
+Not under any circumstance should there ever be a need to upload this folder or any of its contents to a live production server. It's a security risk, and a waste of time.
 :::
 
 ### The Resources Directory
@@ -84,11 +84,11 @@ The `storage` directory contains your compiled Blade templates as well as Sage's
 
 ### The Vendor Directory
 
-The `vendor` directory contains your [Composer](#) dependencies and autoloader. This directory is automatically generated and should not be modified.
+The `vendor` directory contains your [Composer](https://getcomposer.org/) dependencies and autoloader. This directory is automatically generated and should not be modified.
 
 ## The App Directory
 
-The majority of your theme functionality lives in the `app` directory. By default, this directory is namespaced under `App` and is automaticaally loaded by Composer using the [PSR-4 autoloading standard](#).
+The majority of your theme functionality lives in the `app` directory. By default, this directory is namespaced under `App` and is automaticaally loaded by Composer using the [PSR-4 autoloading standard](https://www.php-fig.org/psr/psr-4/).
 
 The `app` directory contains multiple additional directories such as `View` and `Providers` as well as configuration (`setup.php`) and filters (`filters.php`).
 


### PR DESCRIPTION
I've read through Sage 10 docs PR - #249 and made the following changes:

- Structure: Adds hyperlinks and fixes minor typos
- Functionality: Compatiblity: create and update links
- Update links and minor warning box syntax update

One thing that is not clear - should blade/laravel links point to Laravel 7.x or 8.x docs. I've updated them to 8.x at the moment.
