### PR TITLE
Recommend use of Trellis CLI where possible

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -24,6 +24,7 @@ module.exports = {
       },
     },
     'minimal-analytics': { ga: 'UA-71591-42' },
+    'code-switcher': {},
   },
 
   head: [

--- a/docs/trellis/master/database-access.md
+++ b/docs/trellis/master/database-access.md
@@ -1,11 +1,30 @@
 ---
-description: Accessing your WordPress databases in Trellis with Sequel Pro or MySQL Workbench just requires some initial configuration. phpMyAdmin not necessary.
+description: Accessing your WordPress databases in Trellis with Sequel Pro or TablePlus just requires some initial configuration. phpMyAdmin not necessary.
 ---
 
 # Database Access
 
-Accessing your databases with tools such as [Sequel Pro](https://www.sequelpro.com/) and [MySQL Workbench](https://dev.mysql.com/downloads/workbench/) just requires some initial configuration.
+Accessing your databases with client software like [Sequel Pro](https://www.sequelpro.com/) and [TablePlus](http://tableplus.com/) is straight forward with `trellis-cli`:
 
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
+For Sequel Pro:
+```bash
+$ trellis db open --app=sequel-pro production example.com
+```
+
+For TablePlus
+```bash
+$ trellis db open --app=tableplus production example.com
+```
+
+</template>
+<template v-slot:manual>
+
+Configure your Sequel client as follows:
 ## Development (Vagrant box)
 
 - Connection type: SSH
@@ -16,10 +35,6 @@ Accessing your databases with tools such as [Sequel Pro](https://www.sequelpro.c
 - SSH User: `vagrant`
 - SSH Key: Select the following file from your Trellis directory: `.vagrant/machines/default/virtualbox/private_key`
 
-::: tip macOS Users
-[vagrant-trellis-sequel](https://github.com/TypistTech/vagrant-trellis-sequel) allows for opening Trellis databases in Sequel Pro with a single command.
-:::
-
 ## Remote servers
 
 - Connection type: SSH
@@ -29,5 +44,9 @@ Accessing your databases with tools such as [Sequel Pro](https://www.sequelpro.c
 - SSH Host: `example.com`
 - SSH User: `web`
 
-NOTE: If you have provisioned your server to include local or remote ssh keys (see `group_vars/all/users.yml`), you can leave the SSH User password blank  in your DB Application, because SSH already knows about it. (In Sequel Pro the "key" icon toggles a browse field for SSH Key.) Additionally, [Trellis-cli](https://github.com/roots/trellis-cli) provides a one-liner to configure your connection via Sequel Pro or Table Plus.
+::: tip SSH Password?
+Because Trellis provisions remote environments to use [SSH keys](https://roots.io/docs/trellis/master/ssh-keys/) rather than passwords, the password field or prompt is left blank.
+:::
 
+</template>
+</CodeSwitcher>

--- a/docs/trellis/master/deployments.md
+++ b/docs/trellis/master/deployments.md
@@ -24,6 +24,20 @@ At this point, you should also generate your salts and keys and save them to you
 
 Deploy with a single command:
 
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
+```bash
+$ trellis deploy <environment>
+```
+
+</template>
+<template v-slot:manual>
+
+Run the following from your project's `trellis` directory:
+
 ```sh
 $ ./bin/deploy.sh <environment> <domain>
 ```
@@ -33,6 +47,9 @@ $ ./bin/deploy.sh <environment> <domain>
 The actual command looks like this: `ansible-playbook deploy.yml -e "site=<domain> env=<environment>"`.
 
 You can always use this command itself since it can take any additional `ansible-playbook` options.
+
+</template>
+</CodeSwitcher>
 
 ::: warning Note
 **Trellis does not automatically install WordPress on remote servers**.
@@ -169,20 +186,61 @@ wordpress_sites:
 
 Deploy command:
 
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
 ```bash
-$ ./bin/deploy.sh production mysite.com
+$ trellis deploy <environment>
+```
+
+</template>
+<template v-slot:manual>
+
+Run the following from your project's `trellis` directory:
+
+```bash
+$ ./bin/deploy.sh production example.com
 ```
 
 Or alternatively:
 
 ```bash
-$ ansible-playbook deploy.yml -e "site=mysite.com env=production"
+$ ansible-playbook deploy.yml -e "site=example.com env=production"
 ```
+
+</template>
+</CodeSwitcher>
 
 ## Rollbacks
 
-To rollback a deploy, run `ansible-playbook rollback.yml -e "site=<domain> env=<environment>"` .
-You may manually specify a different release using `--extra-vars='release=12345678901234'` . By default Trellis stores 5 previous releases, not including the current release. See `deploy_keep_releases` in [Options - Remote Servers](wordpress-sites.md) to change this setting.
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
+```bash
+$ trellis rollback <environment>
+```
+
+You may manually specify a different release using `--release=12345678901234`.
+
+</template>
+<template v-slot:manual>
+
+Run the following from your project's `trellis` directory:
+
+```bash
+$ ansible-playbook rollback.yml -e "site=<domain> env=<environment>
+```
+
+You may manually specify a different release using `--extra-vars='release=12345678901234'`.
+
+</template>
+</CodeSwitcher>
+
+By default Trellis stores 5 previous releases, not including the current release. See `deploy_keep_releases` in [Options - Remote Servers](wordpress-sites.md) to change this setting.
 
 ## Deploying to other hosts
 

--- a/docs/trellis/master/existing-projects.md
+++ b/docs/trellis/master/existing-projects.md
@@ -66,11 +66,28 @@ If any of the `vault.yml` files look like the example above, follow the [vault i
 
 ## Create Your Development VM
 
+
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
+```bash
+$ trellis up
+```
+
+</template>
+<template v-slot:manual>
+
 Run the following from your project's `trellis` directory:
 
 ```bash
 $ vagrant up
 ```
+
+</template>
+</CodeSwitcher>
+
 
 Confirm you can access the development site at the development URL noted earlier.
 
@@ -82,11 +99,26 @@ Retrieve an export of the current project’s database.
 For easy access during the import process, place the database export in your local project’s `site` directory.
 :::
 
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
+```bash
+$ trellis ssh development
+```
+
+</template>
+<template v-slot:manual>
+
 From your project's `trellis` directory, ssh to the vagrant machine:
 
 ```bash
 $ vagrant ssh
 ```
+
+</template>
+</CodeSwitcher>
 
 Navigate to the web root:
 

--- a/docs/trellis/master/installation.md
+++ b/docs/trellis/master/installation.md
@@ -37,11 +37,16 @@ See a complete working example in the [roots-example-project.com repo](https://g
 
 Pick a descriptive name for your project and use it instead of the default `example.com`. We recommend the domain of the site for convenience.
 
-### With Trellis CLI
+
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
 ```bash
 $ trellis new example.com
 ```
-### Without Trellis CLI
+
+</template>
+<template v-slot:manual>
 
 1. Create a new project directory:
 ```bash
@@ -55,3 +60,6 @@ $ git clone --depth=1 git@github.com:roots/trellis.git && rm -rf trellis/.git
 ```bash
 $ composer create-project roots/bedrock site
 ```
+
+</template>
+</CodeSwitcher>

--- a/docs/trellis/master/installation.md
+++ b/docs/trellis/master/installation.md
@@ -37,6 +37,12 @@ See a complete working example in the [roots-example-project.com repo](https://g
 
 Pick a descriptive name for your project and use it instead of the default `example.com`. We recommend the domain of the site for convenience.
 
+### With Trellis CLI
+```bash
+$ trellis new example.com
+```
+### Without Trellis CLI
+
 1. Create a new project directory:
 ```bash
 $ mkdir example.com && cd example.com

--- a/docs/trellis/master/local-development.md
+++ b/docs/trellis/master/local-development.md
@@ -37,41 +37,13 @@ Trellis installs WordPress on your first `vagrant up` with `admin` as the defaul
 
 Re-provisioning is always assumed to be a safe operation. When you make changes to your Trellis configuration, you should provision the VM again to apply the changes:
 
-
-<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
-<template v-slot:cli>
-
-Run the following from any directory within your project:
-
-```bash
-$ trellis up --with-galaxy
-```
-
-</template>
-<template v-slot:manual>
-
 Run the following from your project's `trellis` directory:
 
 ```bash
 $ vagrant provision
 ```
 
-</template>
-</CodeSwitcher>
-
 You can also provision with specific tags to only run the relevant roles:
-
-<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
-<template v-slot:cli>
-
-Run the following from any directory within your project:
-
-```bash
-$ trellis provision --tags users development
-```
-
-</template>
-<template v-slot:manual>
 
 Run the following from your project's `trellis` directory:
 
@@ -84,9 +56,6 @@ Notes on the commands:
 - `SKIP_GALAXY` saves some time because you already have those roles installed
 - `ANSIBLE_TAGS` runs only the relevant roles
 - `--provision` is so that it runs the `dev.yml` playbook and its roles tagged `wordpress`
-
-</template>
-</CodeSwitcher>
 
 If you added a *new* WordPress site (or manually added new synced directories to Vagrant), you'll need to reload the VM as well:
 

--- a/docs/trellis/master/local-development.md
+++ b/docs/trellis/master/local-development.md
@@ -9,15 +9,15 @@ Development is handled by [Vagrant](https://www.vagrantup.com/) in Trellis. Our 
 1. Configure your site(s) based on the [WordPress Sites docs](wordpress-sites.md) and read the [development specific](wordpress-sites.md#development) ones.
 2. Make sure you've edited both `group_vars/development/wordpress_sites.yml` and `group_vars/development/vault.yml`.
 3. Optionally configure the IP address at the top of the `vagrant.default.yml` to allow for multiple boxes to be run concurrently (default is `192.168.50.5`).
-4. Run `vagrant up` (from your trellis directory, usually the `trellis/` subdirectory of your project).
+4. Run `trellis up` from anywhere in your project (or `vagrant up` from your trellis directory, usually the `trellis/` subdirectory of your project).
 
 ::: warning Note
-`vagrant up` will fail [if you are using encrypted folders/hard drives](https://www.vagrantup.com/docs/synced-folders/nfs.html#other-notes)
+`trellis up` will fail [if you are using encrypted folders/hard drives](https://www.vagrantup.com/docs/synced-folders/nfs.html#other-notes)
 :::
 
 Then let Vagrant and Ansible do their thing. After roughly 5-10 minutes you'll have a server running and a WordPress site automatically installed and configured.
 
-To access the VM, run `vagrant ssh`. Sites can be found at `/srv/www/<site name>`. See the [Vagrant docs](https://www.vagrantup.com/docs/cli/) for more commands.
+To access the VM, run `trellis ssh development` (or`vagrant ssh` from your `trellis` directory). Sites can be found at `/srv/www/<site name>`. See the [Vagrant docs](https://www.vagrantup.com/docs/cli/) for more commands.
 
 Note that each WP site you configured is synced between your local machine (the host) and the Vagrant VM. Any changes made to your host will be synced to the VM.
 
@@ -27,6 +27,7 @@ Mounting an encrypted folder is not possible with Trellis due to an issue with N
 
 ::: tip Windows user?
 Windows users have a slightly different workflow. See the [Windows getting started docs](../../getting-started/windows.md).
+:::
 
 ## WordPress installation
 
@@ -36,14 +37,46 @@ Trellis installs WordPress on your first `vagrant up` with `admin` as the defaul
 
 Re-provisioning is always assumed to be a safe operation. When you make changes to your Trellis configuration, you should provision the VM again to apply the changes:
 
+
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
+```bash
+$ trellis provision development
+```
+
+</template>
+<template v-slot:manual>
+
+Run the following from your project's `trellis` directory:
+
 ```bash
 $ vagrant provision
 ```
 
+</template>
+</CodeSwitcher>
+
 You can also provision with specific tags to only run the relevant roles:
 
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
 ```bash
-$ SKIP_GALAXY=true ANSIBLE_TAGS=wordpress vagrant provision
+$ trellis provision --tags users development
+```
+
+</template>
+<template v-slot:manual>
+
+Run the following from your project's `trellis` directory:
+
+```bash
+$ SKIP_GALAXY=true ANSIBLE_TAGS=users vagrant provision
 ```
 
 Notes on the commands:
@@ -51,6 +84,9 @@ Notes on the commands:
 - `SKIP_GALAXY` saves some time because you already have those roles installed
 - `ANSIBLE_TAGS` runs only the relevant roles
 - `--provision` is so that it runs the `dev.yml` playbook and its roles tagged `wordpress`
+
+</template>
+</CodeSwitcher>
 
 If you added a *new* WordPress site (or manually added new synced directories to Vagrant), you'll need to reload the VM as well:
 

--- a/docs/trellis/master/local-development.md
+++ b/docs/trellis/master/local-development.md
@@ -44,7 +44,7 @@ Re-provisioning is always assumed to be a safe operation. When you make changes 
 Run the following from any directory within your project:
 
 ```bash
-$ trellis provision development
+$ trellis up --with-galaxy
 ```
 
 </template>

--- a/docs/trellis/master/mail.md
+++ b/docs/trellis/master/mail.md
@@ -17,7 +17,7 @@ Enter [MailHog](https://github.com/mailhog/MailHog). It’s a simple tool which 
 
 ![Mailhog Preview](https://cdn.roots.io/app/uploads/trellis-mailhog-preview.png)
 
-MailHog is automatically set up in development. You can access it at `http://yourdevelopmentdomain.test:8025` (replacing the domain with yours that you set up for the WP site host).
+MailHog is automatically set up in development. You can access it at `http://example.test:8025` (replacing the domain with yours that you set up for the WP site host).
 
 ::: warning Note
 Mail will be automatically captured but you won't ever see it unless you access the MailHog UI at the address above.
@@ -41,7 +41,7 @@ ssl:
   hsts_max_age: 0
 ```
 
-Then reprovision your Vagrant box in order to reach MailHog at `http://yourdevelopmentdomain.test:8025`.
+Then reprovision your Vagrant box in order to reach MailHog at `http://example.test:8025`.
 
 ## Remote servers (staging/production)
 
@@ -86,4 +86,3 @@ To fix this error, update your SMTP settings so that they're valid and then re-p
 ### Revaliases
 
 By default some system daemons, like `cron` send email from the hostname like this: `root@mydroplet-ubuntu-s-1cpu-1gb-nyc3`. To avoid blocked or spammed messages, configure sSMTP "revaliases" in `trellis/roles/ssmtp/defaults/main.yml`, and deploy the `mail` tasks, which will populate the `/etc/ssmtp/revaliases` file on the server.
-

--- a/docs/trellis/master/remote-server-setup.md
+++ b/docs/trellis/master/remote-server-setup.md
@@ -21,34 +21,17 @@ Trellis has two main [playbooks](http://docs.ansible.com/ansible/playbooks.html)
 
 For remote servers, you provision a server via the `server.yml` playbook. This leaves you with a server *prepared* to run a WordPress site, but without the actual codebase yet.
 
-## Deploy
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
 
-In development it's easy to get your site/codebase onto the VM through synced folders. However for remote servers, we need to deploy first.
+Run the following from any directory within your project:
 
-Deploys are done in Trellis by running the `deploy.yml` playbook. This gets your codebase onto the server by cloning it from a Git repository. It also takes cares of things like: running Composer, creating config files, reloading Nginx, etc.
+```bash
+$ trellis provision <environment>
+```
 
-## Requirements
-
-The Trellis [installation instructions](installing-trellis.md) skipped a few requirements because Vagrant handles them automatically for us.
-
-To use Trellis for remote servers, we recommend installing Ansible locally on your host machine ([except for Windows users](../../getting-started/windows.md)).
-
-1. Install Ansible and other dependencies: `pip install -r requirements.txt`
-2. Install Galaxy roles: `ansible-galaxy install -r galaxy.yml` (in local trellis directory)
-
-Then there are two additional requirements for the remote server itself:
-
-1. You need a server running a bare/stock version of Ubuntu 18.04 LTS (Bionic Beaver). If you're using a host such as DigitalOcean, then just select their Ubuntu 18.04 option.
-
-::: warning Note
-Ubuntu 16.04 (Xenial) is still supported as well so you don't need to migrate yet. See [#992](https://github.com/roots/trellis/pull/992) for details on the minor changes needed to run it.
-:::
-
-**You can't run Trellis on a shared host**.
-
-2. You need to be able to connect to your server from your local computer via SSH. We *highly* suggest doing this via SSH keys so you don't have to specify a password every time. Many hosts like DigitalOcean offer to automatically add your SSH key when creating a server so take advantage of that. Or follow a guide such as [this one](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2).
-
-Now that you have a working Ubuntu 18.04 server that you can easily SSH into, you need to configure a few things:
+</template>
+<template v-slot:manual>
 
 1. Copy your `wordpress_sites` from your working development site in `group_vars/development/wordpress_sites.yml` to `group_vars/<environment>/wordpress_sites.yml` (`staging` or `production`, whichever you're setting up).
 2. Modify your site and add the necessary settings for [remote servers](wordpress-sites.md#remote-servers) since they have a few more settings than local development. Also see the [Passwords docs](passwords.md).
@@ -57,21 +40,116 @@ Now that you have a working Ubuntu 18.04 server that you can easily SSH into, yo
 5. Consider setting `sshd_permit_root_login: false` in `group_vars/all/security.yml`. See the [Security docs](security.md).
 6. Run `ansible-playbook server.yml -e env=<environment>` from your local machine (Ansible connects to your remote server via SSH).
 
+Run the following from your project's `trellis` directory:
+
+```bash
+$ ansible-playbook server.yml -e env=<environment>
+```
+
+</template>
+</CodeSwitcher>
+
+## Deploy
+
+In development it's easy to get your site/codebase onto the VM through synced folders. However for remote servers, we need to deploy first.
+
+Deploys are done in Trellis by running the `deploy.yml` playbook. This gets your codebase onto the server by cloning it from a Git repository. It also takes cares of things like: running Composer, creating config files, reloading Nginx, etc.
+
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
+```bash
+$ trellis deploy <environment>
+```
+
+</template>
+<template v-slot:manual>
+
+Run the following from your project's `trellis` directory:
+
+```bash
+$ ./bin/deploy.sh <environment> example.com
+```
+
+</template>
+</CodeSwitcher>
+
+## Requirements
+
+The Trellis [installation instructions](installing-trellis.md) skipped a few requirements because Vagrant handles them automatically for us.
+
+To use Trellis for remote servers, we recommend installing Ansible locally on your host machine ([except for Windows users](../../getting-started/windows.md)).
+
+If you're not using `trellis-cli` to provision your servers, install Ansible dependencies and Galaxy roles:
+1. Install Ansible and other dependencies: `pip install -r requirements.txt`
+2. Install Galaxy roles: `ansible-galaxy install -r galaxy.yml` (in local trellis directory)
+
+Then there are two additional requirements for the remote server itself:
+
+1. You need a server running a bare/stock version of Ubuntu 18.04 LTS (Bionic Beaver). If you're using a host such as DigitalOcean, then select their Ubuntu 18.04 option.
+
+::: warning Note
+Ubuntu 16.04 (Xenial) is still supported as well so you don't need to migrate yet. See [#992](https://github.com/roots/trellis/pull/992) for details on the minor changes needed to run it.
+:::
+
+**You cannot run Trellis on a shared host**.
+
+2. You need to be able to connect to your server from your local computer via SSH. We *highly* suggest doing this via SSH keys so you don't have to specify a password every time. Many hosts like DigitalOcean offer to automatically add your SSH key when creating a server so take advantage of that. Or follow a guide such as [this one](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2).
+
+Now that you have a working Ubuntu 18.04 server that you can easily SSH into, you need to configure a few things:
+
 This leaves you with a *provisioned* server. The next step is to [deploy](deployments.md) your site.
 
 ## Re-provisioning
 
 Re-provisioning is always assumed to be a safe operation. When you make changes to your Trellis configuration, you should provision your remote servers again to apply the changes:
 
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
+```bash
+$ trellis provision <environment>
+```
+
+</template>
+<template v-slot:manual>
+
+Run the following from your project's `trellis` directory:
+
 ```bash
 $ ansible-playbook server.yml -e env=<environment>
 ```
 
+</template>
+</CodeSwitcher>
+
 You can also provision with specific tags to only run the relevant roles:
+
+
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+Run the following from any directory within your project:
+
+```bash
+$ trellis provision --tags users <environment>
+```
+
+</template>
+<template v-slot:manual>
+
+Run the following from your project's `trellis` directory:
 
 ```bash
 $ ansible-playbook server.yml -e env=<environment> --tags=users
 ```
+
+</template>
+</CodeSwitcher>
 
 ## Resources
 

--- a/docs/trellis/master/vault.md
+++ b/docs/trellis/master/vault.md
@@ -27,6 +27,24 @@ $ANSIBLE_VAULT;1.1;AES256
 
 ## Steps to enable Ansible Vault
 
+::: danger
+If you have unencrypted `vault.yml` files in your project's git history (e.g., passwords in plain text), you will most likely want to change the variable values in your `vault.yml` files before encrypting them and committing them to your repo.
+:::
+
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+### Encrypt files
+`trellis-cli` automatically generates your vault files and a vault password, but does not encrypt your vaults. To encrypt vaults created by `trellis-cli` run the following from any directory within your project:
+
+
+```bash
+$ trellis vault encrypt --files=group_vars/all/vault.yml group_vars/development/vault.yml group_vars/staging/vault.yml group_vars/production/vault.yml
+```
+
+</template>
+<template v-slot:manual>
+
 ### 1. Set vault password
 
 Generate a long random password and save it as a string on a single line in a new file. Name the file `.vault_pass` and save it at the root of this project (e.g., next to `ansible.cfg`). You will probably want to run `chmod 600 .vault_pass` to restrict access to this file. This `.vault_pass` file will remain in plain text and should _not_ be committed to your repo, so be sure that it is included in your `.gitignore` file.
@@ -50,17 +68,31 @@ If you prefer not to set this default in your `ansible.cfg` file, you can add th
 
 ### 3. Encrypt files
 
-::: danger
-If you have unencrypted `vault.yml` files in your project's git history (e.g., passwords in plain text), you will most likely want to change the variable values in your `vault.yml` files before encrypting them and committing them to your repo.
-:::
-
 Encrypt your `vault.yml` files with the command `ansible-vault encrypt <file>`. The example below uses the command to encrypt the full list of `vault.yml` files (fileglobs are not supported, see [https://github.com/ansible/ansible/issues/6241](https://github.com/ansible/ansible/issues/6241)):
+
+Run the following from your project's `trellis` directory:
 
 ```bash
 $ ansible-vault encrypt group_vars/all/vault.yml group_vars/development/vault.yml group_vars/staging/vault.yml group_vars/production/vault.yml
 ```
 
+</template>
+</CodeSwitcher>
+
 ## Other vault commands
+
+<CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
+<template v-slot:cli>
+
+`trellis-cli` provides a few notable commands that coincide with the official [Ansible Vault](http://docs.ansible.com/ansible/playbooks_vault.html) docs.
+
+- `trellis vault encrypt <file>`
+- `trellis vault view <file>`
+- `trellis vault edit <file>`
+- `trellis vault decrypt <file>` -- Avoid using the `decrypt` command. If your intention is to view or edit an encrypted file, use the `view` or `edit` commands instead. Any time you decrypt a file, you risk forgetting to re-encrypt the file before committing changes to your repo.
+
+</template>
+<template v-slot:manual>
 
 Here are a few notable commands from the official [Ansible Vault](http://docs.ansible.com/ansible/playbooks_vault.html) docs.
 
@@ -69,6 +101,9 @@ Here are a few notable commands from the official [Ansible Vault](http://docs.an
 - [`ansible-vault edit <file>`](http://docs.ansible.com/ansible/playbooks_vault.html#editing-encrypted-files)
 - [`ansible-vault decrypt <file>`](http://docs.ansible.com/ansible/playbooks_vault.html#decrypting-encrypted-files) -- Avoid using the `decrypt` command. If your intention is to view or edit an encrypted file, use the `view` or `edit` commands instead. Any time you decrypt a file, you risk forgetting to re-encrypt the file before committing changes to your repo.
 - [`ansible-vault rekey <file>`](http://docs.ansible.com/ansible/playbooks_vault.html#rekeying-encrypted-files)
+
+</template>
+</CodeSwitcher>
 
 ## Working with vault variables
 

--- a/docs/trellis/master/wordpress-sites.md
+++ b/docs/trellis/master/wordpress-sites.md
@@ -1,8 +1,11 @@
 ---
 description: Everything in Trellis is built around the concept of "sites". Trellis will automatically configure everything needed to host a WordPress site.
 ---
-
 # WordPress Sites
+
+::: tip Note
+If you used `trellis-cli` to create your project these values will already be set.
+:::
 
 Now that you have Trellis' requirements installed and a local project set up, the next thing to do is configure a WordPress site.
 

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "vuepress-plugin-clean-urls": "^1.1.1",
     "vuepress-plugin-minimal-analytics": "^0.1.4",
     "vuepress-plugin-sitemap": "^2.3.1"
+  },
+  "dependencies": {
+    "vuepress-plugin-code-switcher": "^1.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,10 +991,32 @@
   dependencies:
     "@vuepress/shared-utils" "^1.3.0"
 
+"@vuepress/plugin-register-components@^1.8.0":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@vuepress/plugin-register-components/-/plugin-register-components-1.8.2.tgz#2fb45a68b0a1efb8822670d95c3b231a2d0eb74d"
+  integrity sha512-6SUq3nHFMEh9qKFnjA8QnrNxj0kLs7+Gspq1OBU8vtu0NQmSvLFZVaMV7pzT/9zN2nO5Pld5qhsUJv1g71MrEA==
+  dependencies:
+    "@vuepress/shared-utils" "1.8.2"
+
 "@vuepress/plugin-search@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@vuepress/plugin-search/-/plugin-search-1.3.0.tgz#ec3619a2d70696f7f91575121f4b7409ba229d07"
   integrity sha512-buoQ6gQ2MLbLQ7Nhg5KJWPzKo7NtvdK/e6Fo1ig/kbOG5HyYKHCyqLjbQ/ZqT+fGbaSeEjH3DaVYTNx55GRX5A==
+
+"@vuepress/shared-utils@1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@vuepress/shared-utils/-/shared-utils-1.8.2.tgz#5ec1601f2196aca34ad82eed7c9be2d7948f705b"
+  integrity sha512-6kGubc7iBDWruEBUU7yR+sQ++SOhMuvKWvWeTZJKRZedthycdzYz7QVpua0FaZSAJm5/dIt8ymU4WQvxTtZgTQ==
+  dependencies:
+    chalk "^2.3.2"
+    escape-html "^1.0.3"
+    fs-extra "^7.0.1"
+    globby "^9.2.0"
+    gray-matter "^4.0.1"
+    hash-sum "^1.0.2"
+    semver "^6.0.0"
+    toml "^3.0.0"
+    upath "^1.1.0"
 
 "@vuepress/shared-utils@^1.3.0":
   version "1.3.0"
@@ -8193,6 +8215,13 @@ vuepress-plugin-clean-urls@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vuepress-plugin-clean-urls/-/vuepress-plugin-clean-urls-1.1.1.tgz#593f47be643c33c34413ba408e8bee31aaf534bd"
   integrity sha512-cEDbqme8rPbkSbjz73ONFSKIZkzC8HFRBY7UD/oa1ZC655HYhQo3JMbJgJXeCQjV/vkl7WuPB/QMNlQY20PXjw==
+
+vuepress-plugin-code-switcher@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/vuepress-plugin-code-switcher/-/vuepress-plugin-code-switcher-1.0.5.tgz#6c7143e3640abfcbb93a1adddf7637c5e00fe512"
+  integrity sha512-vFq5Nmud+96vKRyBq9FoKq9nNRhs4BhfrZfeZW1RvPtSVnQIAq5Pfs6I/wMZmeXxBvvcIDTnhoVuz3tUQ9glrA==
+  dependencies:
+    "@vuepress/plugin-register-components" "^1.8.0"
 
 vuepress-plugin-container@^2.0.2:
   version "2.1.2"


### PR DESCRIPTION
* Add [code-switcher](https://github.com/padarom/vuepress-plugin-code-switcher) as a Vuepress dependency (thanks @swalkinshaw!)
* Rewrite and lightly reorganize Trellis documentation to recommend `trellis-cli` methods first, and "manual" methods second using code-switcher.