### PR TITLE
Switch vagrant install to brew's updated syntax for installing from a cask.

### DIFF
--- a/docs/getting-started/macos.md
+++ b/docs/getting-started/macos.md
@@ -120,7 +120,7 @@ Download and install the "OS X Hosts" version of VirtualBox from [https://www.vi
 Install Vagrant from Homebrew:
 
 ```bash
-$ brew cask install vagrant
+$ brew install -cask vagrant
 ```
 
 ### Ansible


### PR DESCRIPTION
Switch to current brew's syntax for installing from a cask.