### PR TITLE
trellis-cli documentation

### DIFF
--- a/docs/trellis-cli/README.md
+++ b/docs/trellis-cli/README.md
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;url=https://roots.io/docs/trellis-cli/master/installation/" />

--- a/docs/trellis-cli/master/installation.md
+++ b/docs/trellis-cli/master/installation.md
@@ -1,0 +1,61 @@
+---
+description: A command-line interface (CLI) to manage Trellis projects via the trellis command.
+---
+
+trellis-cli includes the following useful command-line enhancements to the Trellis experience:
+* Smart autocompletion (based on your defined environments and sites)
+* Automatic Virtualenv integration for easier dependency management
+* Easy DigitalOcean droplet creation
+* Better Ansible Vault support for encrypting files
+
+# Installation
+## Quick Installation (macOS and Linux via Homebrew)
+
+```bash
+brew install roots/tap/trellis-cli
+```
+
+## Script Installation
+We also offer a quick script version:
+
+### You might need sudo before bash
+```bash
+curl -sL https://roots.io/trellis/cli/get | bash
+```
+
+### Turns on debug logging
+```bash
+curl -sL https://roots.io/trellis/cli/get | bash -s -- -d
+```
+
+### Sets bindir or installation directory, Defaults to '/usr/local/bin'
+```bash
+curl -sL https://roots.io/trellis/cli/get | bash -s -- -b /path/to/my/bin
+```
+
+# Usage
+
+Run `trellis` for the complete usage and help.
+
+Supported commands so far:
+
+| Command | Description |
+| --- | --- |
+| `alias` | Generate WP CLI aliases for remote environments |
+| `check` | Checks if Trellis requirements are met |
+| `db` | Commands for database management |
+| `deploy` | Deploys a site to the specified environment |
+| `dotenv` | Template .env files to local system |
+| `down` | Stops the Vagrant machine by running `vagrant halt`|
+| `droplet` | Commands for DigitalOcean Droplets |
+| `exec` | Exec runs a command in the Trellis virtualenv |
+| `galaxy` | Commands for Ansible Galaxy |
+| `info` | Displays information about this Trellis project |
+| `init` | Initializes an existing Trellis project |
+| `new` | Creates a new Trellis project |
+| `provision` | Provisions the specified environment |
+| `rollback` | Rollsback the last deploy of the site on the specified environment |
+| `ssh` | Connects to host via SSH |
+| `up` | Starts and provisions the Vagrant environment by running `vagrant up` |
+| `valet` | Commands for Laravel Valet |
+| `vault` | Commands for Ansible Vault |

--- a/docs/trellis-cli/master/shell-integration.md
+++ b/docs/trellis-cli/master/shell-integration.md
@@ -1,0 +1,29 @@
+---
+description: Homebrew installs trellis-cli's shell completion automatically by default. If shell completions aren't working, or you installed manually not using Homebrew, you'll need to install the completions manually.
+---
+
+# Autocompletes
+
+Homebrew installs trellis-cli's shell completion automatically by default. If shell completions aren't working, or you installed manually not using Homebrew, you'll need to install the completions manually.
+
+To use the trellis-cli's autocomplete via Homebrew's shell completion:
+
+Follow [Homebrew's install instructions](https://docs.brew.sh/Shell-Completion).
+
+::: tip Note
+For zsh, as the instructions mention, be sure compinit is autoloaded and called, either explicitly or via a framework like oh-my-zsh.
+:::
+
+Once Shell-Completion is installed, run the following:
+
+```bash
+brew reinstall trellis-cli
+```
+
+To install shell completions manually, run the following:
+
+```bash
+trellis --autocomplete-install
+```
+
+This should modify your `.bash_profile`, `.zshrc` or similar.

--- a/docs/trellis-cli/master/virtualenv.md
+++ b/docs/trellis-cli/master/virtualenv.md
@@ -1,0 +1,19 @@
+---
+description: trellis-cli uses Virtualenv to manage dependencies such as Ansible which it automatically activates and uses when running any trellis command. 
+---
+
+There are many times you may want to run `ansible-playbook` or `pip` manually in your shell. To make this experience seamless, `trellis-cli` offers shell integration which automatically activates the Virtualenv when you enter a Trellis project, and deactivates when you leave it.
+
+To enable this integration, add the following to your shell profile:
+
+Bash (`~/.bash_profile`):
+
+```bash
+eval "$(trellis shell-init bash)"
+```
+
+Zsh (`~/.zshrc`):
+
+```bash
+eval "$(trellis shell-init zsh)"
+```

--- a/docs/trellis/master/user-contributed-extensions.md
+++ b/docs/trellis/master/user-contributed-extensions.md
@@ -28,6 +28,7 @@ Issues with extensions should be opened in their respective repositories.
 ](https://github.com/ItinerisLtd/trellis-slack-webhook-notify-during-deploy) - Sends a deployment complete message to a Slack channel when Trellis deploys Bedrock
 - [trellis_install_wp_cli_via_composer](https://github.com/ItinerisLtd/trellis_install_wp_cli_via_composer) - Install WP-CLI via composer on Trellis servers
 - [tiller-circleci-orb](https://github.com/ItinerisLtd/tiller-circleci-orb/) - Deploy Trellis, Bedrock and Sage(optional) via CircleCI
+- [trellis-cyberduck](https://github.com/ItinerisLtd/trellis-cyberduck) - Trellis commands for Cyberduck
 - tiller (abandoned, functionality was replaced by [tiller-circleci-orb](https://github.com/ItinerisLtd/tiller-circleci-orb/)) - Deploy Trellis, Bedrock and Sage via AWS CodeBuild
 - enveigle (abandoned, functionality was merged into [trellis-cli](https://github.com/roots/trellis-cli)) - Deceive Ansible to template Trellis .env files to local Bedrock
 - cognomen (abandoned, functionality was merged into [trellis-cli](https://github.com/roots/trellis-cli)) - Generate WP CLI aliases for Trellis projects


### PR DESCRIPTION
- `trellis-cli` documentation, copied from GitHub and reorganized
- Closes #271 
