### PR TITLE
Fix command: Double hyphen `--cask`

### DIFF
--- a/docs/getting-started/macos.md
+++ b/docs/getting-started/macos.md
@@ -120,7 +120,7 @@ Download and install the "OS X Hosts" version of VirtualBox from [https://www.vi
 Install Vagrant from Homebrew:
 
 ```bash
-$ brew install -cask vagrant
+$ brew install --cask vagrant
 ```
 
 ### Ansible


### PR DESCRIPTION
```sh-session
$ brew install -cask vagrant

Error: ambiguous option: -cask
```

Follow up #270