### PR TITLE
Document db_prefix

### DIFF
--- a/docs/trellis/master/wordpress-sites.md
+++ b/docs/trellis/master/wordpress-sites.md
@@ -108,6 +108,7 @@ example.com:
   - `db_user` - database username (default: `<site name>`)
   - `db_password` - database password (*required*, in `vault.yml`)
   - `db_host` - database hostname (default: `localhost`)
+  - `db_prefix` - database table prefix (defaults to `wp_` if not set)
   - `db_user_host` - hostname or ip range used to restrict connections to database (default: `localhost`)
 
 ### Development


### PR DESCRIPTION
Sets the `$table_prefix` for WordPress, see:
https://discourse.roots.io/t/change-table-prefix-for-wp-config-in-trellis/9607
Maybe should be documented here.