### PR TITLE
Update letsencrypt url for staging env

### DIFF
--- a/docs/trellis/master/ssl.md
+++ b/docs/trellis/master/ssl.md
@@ -142,7 +142,7 @@ Just set the following variable:
 
 ```yaml
 # in a group_vars file
-letsencrypt_ca: "https://acme-staging.api.letsencrypt.org"
+letsencrypt_ca: "https://acme-staging-v02.api.letsencrypt.org"
 ```
 
 #### Troubleshooting Let's Encrypt


### PR DESCRIPTION
Got an error with the old url, so. As described here: https://letsencrypt.org/docs/staging-environment/ since end of march, the new url is https://acme-staging-v02.api.letsencrypt.org