### PR TITLE
Sage 9.x is not compatible with PHP 8

### DIFF
--- a/docs/sage/9.x/installation.md
+++ b/docs/sage/9.x/installation.md
@@ -7,7 +7,7 @@ description: Install Sage with Composer (composer create-project roots/sage), wh
 Make sure all dependencies have been installed before moving on:
 
 - [WordPress](https://wordpress.org/) >= 4.7
-- [PHP](http://php.net/manual/en/install.php) >= 7.1.3 (with [`php-mbstring`](http://php.net/manual/en/book.mbstring.php) enabled)
+- [PHP](http://php.net/manual/en/install.php) >= 7.1.3 (with [`php-mbstring`](http://php.net/manual/en/book.mbstring.php) enabled). *Not compatible with PHP 8*
 - [Composer](https://getcomposer.org/download/)
 - [Node.js](http://nodejs.org/) >= 8.0.0
 - [Yarn](https://yarnpkg.com/en/docs/install)


### PR DESCRIPTION
Sage 9.x is not compatible with PHP 8. It makes sense to make it clear on this page.
Detailed discussion: https://discourse.roots.io/t/sage-9-illuminate-support-not-compatible-with-php-8/19739/3