### PR TITLE
Add Sequel Ace as alternative to Sequel Pro

### DIFF
--- a/docs/trellis/master/database-access.md
+++ b/docs/trellis/master/database-access.md
@@ -4,14 +4,14 @@ description: Accessing your WordPress databases in Trellis with Sequel Pro or Ta
 
 # Database Access
 
-Accessing your databases with client software like [Sequel Pro](https://www.sequelpro.com/) and [TablePlus](http://tableplus.com/) is straight forward with `trellis-cli`:
+Accessing your databases with client software like [Sequel Pro](https://www.sequelpro.com/), [Sequel Ace](https://sequel-ace.com/) and [TablePlus](http://tableplus.com/) is straight forward with `trellis-cli`:
 
 <CodeSwitcher :languages="{cli:'Trellis CLI',manual:'Manual'}">
 <template v-slot:cli>
 
 Run the following from any directory within your project:
 
-For Sequel Pro:
+For Sequel Pro (or Sequel Ace):
 ```bash
 $ trellis db open --app=sequel-pro production example.com
 ```


### PR DESCRIPTION
[Sequel Ace](https://sequel-ace.com/) is based on Sequel Pro. It seems Sequel Pro is not active developed at the moment. At least [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) shows more activity lately. See the discussion [here](https://github.com/sequelpro/sequelpro/issues/3705) for context.

Opening a database with Sequel Ace already works with the [trellis-cli](https://github.com/roots/trellis-cli) command:

`trellis db open --app=sequel-pro production example.com`

If you are adding it to the docs, maybe adding a `--app=sequel-ace` parameter in Trellis Cli is a good thing to do as well?
