### PR TITLE
redirect logo url to getting started

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -6,6 +6,7 @@ export default ({ router }) => {
     { path: '/bedrock/', redirect: '/bedrock/master/installation/' },
     { path: '/examples/', redirect: '/examples/roots-example-project/' },
     { path: '/getting-started/', redirect: '/getting-started/macos/' },
+    { path: '/', redirect: '/getting-started/macos/' },
     { path: '/sage/', redirect: '/sage/10.x/installation/' },
     { path: '/sage/8.x', redirect: '/sage/8.x/installation/' },
     { path: '/sage/9.x', redirect: '/sage/9.x/installation/' },


### PR DESCRIPTION
After navigate the documentation when you click on logo will get an 404
since we will have redirect on netlify for external trafic and not when
vue-router handle navigation