### PR TITLE
Update Vagrant docs for Trellis

### DIFF
--- a/docs/getting-started/macos.md
+++ b/docs/getting-started/macos.md
@@ -107,20 +107,32 @@ $ npm install --global yarn
 
 Trellis relies on a few additional software packages to function. Install these packages:
 
-- VirtualBox >= 4.3.10
-- Vagrant >= 2.1.0
+- [Vagrant](https://www.vagrantup.com/downloads.html) >= 2.1.0
+- a Vagrant [provider](https://www.vagrantup.com/docs/providers):
+  - Intel based Macs: [VirtualBox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
+  - Apple Silicon (M1) based Macs: [Parallels Pro](../trellis/master/vagrant.md) >= v17
 - Ansible >= 2.5.3
 
-### VirtualBox
+### VirtualBox (Intel Macs)
 
 Download and install the "OS X Hosts" version of VirtualBox from [https://www.virtualbox.org/wiki/Downloads](https://www.virtualbox.org/wiki/Downloads)
 
+### Parallels (Apple Silicon (M1) Macs)
+See our [Vagrant docs](../trellis/master/vagrant.md) for details.
+
 ### Vagrant
 
-Install Vagrant from Homebrew:
+We recommend installing Vagrant through their official installers: [Vagrant
+downloads](https://www.vagrantup.com/downloads)
+
+We _don't recommend_ Homebrew for two reasons:
+1. brew automatically upgrades packages now by default which can cause issues
+2. it's very hard to downgrade to an older specific version of Vagrant if need be
+
+If you really want to use Homebrew to manage Vagrant, then run the following:
 
 ```bash
-$ brew install --cask vagrant
+$ brew install vagrant
 ```
 
 ### Ansible

--- a/docs/trellis/master.js
+++ b/docs/trellis/master.js
@@ -19,7 +19,7 @@ module.exports = [
       'master/passwords',
       'master/database-access',
       'master/server-logs',
-      'master/vagrantfile',
+      'master/vagrant',
     ],
   },
   {

--- a/docs/trellis/master/installation.md
+++ b/docs/trellis/master/installation.md
@@ -1,13 +1,15 @@
 ---
-description: Before installing Trellis the requirements must be met. After installing Ansible, Virtualbox, and Vagrant, setup your Trellis directory structure.
+description: Trellis installation and new project instructions.
 ---
 
 # Installation
 
 Trellis relies on a few other software tools. Make sure all dependencies have been installed before moving on:
 
-- [Virtualbox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
 - [Vagrant](https://www.vagrantup.com/downloads.html) >= 2.1.0
+- a Vagrant [provider](https://www.vagrantup.com/docs/providers):
+  - x86 (Intel based Macs, Linux, Windows PCs): [VirtualBox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
+  - Apple Silicon (M1 based Macs): See our [Parallels page](./vagrant.md#Parallels)
 - *Recommended* [trellis-cli](https://github.com/roots/trellis-cli)
 
 ::: tip Windows user?

--- a/docs/trellis/master/vagrant.md
+++ b/docs/trellis/master/vagrant.md
@@ -1,0 +1,49 @@
+# Vagrant
+
+## Providers
+Trellis supports most of Vagrant's common [providers](https://www.vagrantup.com/docs/providers) automatically. By default we recommend VirtualBox since it's free and open source. However, if you prefer some of the commercial products like VMWare or Parallels, feel free to use them.
+
+This main exception here is for developers on Macs with Apple Silicon (M1)
+chips. Because these are ARM-based CPUs, VirtualBox won't work; it's limited to
+x86 CPUs like Intel and AMD.
+
+### Parallels (Apple Silicon (M1) Macs)
+Currently Parallels is the best solution for running virtual machines on Apple
+Silicon based Macs. Unfortunately, Parallels is a paid and commercial product
+unlike VirtualBox. Parallels **Pro** is required as well which has a yearly
+subscription price of
+$99 USD.
+
+::: tip
+If you'd like to support Roots, please [purchase Parallels Pro through our affiliate link](https://prf.hn/l/KzkNLZB">https://prf.hn/l/KzkNLZB)
+:::
+
+Installation:
+1. Purchase Parallels Pro
+2. Install Parallels
+3. Install the Vagrant provider: `vagrant plugin install vagrant-parallels`
+
+See the [Parallels site](https://parallels.github.io/vagrant-parallels/docs/) for
+more details.
+
+As of January 2022, the Vagrant box needs to changed as well since the default one doesn't support Ubuntu for ARM yet.
+
+Update the following two settings in `vagrant.default.yml` (or
+   `vagrant.local.yml`)
+```yaml
+vagrant_box: 'jeffnoxon/ubuntu-20.04-arm64'
+vagrant_box_version: '>= 1.0.0'
+```
+
+Follow the [GitHub issue](https://github.com/roots/trellis/issues/1253) for
+updates and discussion.
+
+## Configuration
+Editing the `Vagrantfile` directly should be avoided unless necessary. Instead,
+you can easily set common settings in `vagrant.default.yml`.
+
+To make _local_ overrides, create a `vagrant.local.yml` file with any overrides
+you want. Note: this file is Git ignored.
+
+## Vagrantfile
+The example `Vagrantfile` in this project can be kept in this folder or moved anywhere else such as a project/site folder. Generally, if you want to have multiple sites on 1 Vagrant VM, you should keep the `Vagrantfile` where it is (in the trellis dir). If you want to have 1 Vagrant VM *per* project/site, you should make copies of the `Vagrantfile` and put them into each project's dir. You'd then run `vagrant up` from the project-specific directory.

--- a/docs/trellis/master/vagrantfile.md
+++ b/docs/trellis/master/vagrantfile.md
@@ -1,5 +1,0 @@
-# Vagrantfile
-
-The example `Vagrantfile` in this project can be kept in this folder or moved anywhere else such as a project/site folder. Generally, if you want to have multiple sites on 1 Vagrant VM, you should keep the `Vagrantfile` where it is (in the trellis dir). If you want to have 1 Vagrant VM *per* project/site, you should make copies of the `Vagrantfile` and put them into each project's dir. You'd then run `vagrant up` from the project-specific directory.
-
-Edit `vagrant.default.yml` to modify configuration settings.


### PR DESCRIPTION
Expands on the Vagrant requirements and documents what's needed for Apple Silicon based Macs.