### PR TITLE
💄 code tag: avoid possible confusion w/ color/link

### DIFF
--- a/docs/.vuepress/theme/styles/index.scss
+++ b/docs/.vuepress/theme/styles/index.scss
@@ -160,10 +160,6 @@ body {
       @apply .my-2 .mx-0;
     }
 
-    code {
-      @apply .text-brand-500;
-    }
-
     div[class*="language-"] {
       @apply .bg-white .shadow .border .my-6;
 

--- a/docs/.vuepress/theme/styles/index.scss
+++ b/docs/.vuepress/theme/styles/index.scss
@@ -159,6 +159,10 @@ body {
     ol li {
       @apply .my-2 .mx-0;
     }
+    
+    a code {
+      @apply .text-brand-500;
+    }
 
     div[class*="language-"] {
       @apply .bg-white .shadow .border .my-6;


### PR DESCRIPTION
this PR removes the brand color set on code

content in `<code>` tags currently could be mistaken for links