### PR TITLE
fix ansible doc url

### DIFF
--- a/docs/trellis/master/remote-server-setup.md
+++ b/docs/trellis/master/remote-server-setup.md
@@ -17,7 +17,7 @@ For remote servers, the workflow is a little different with two new concepts:
 
 Provisioning a server means to set it up with the necessary software and configuration to run a WordPress site. For Trellis this means things like: installing MariaDB, installing Nginx, configuring Nginx, creating a database, etc.
 
-Trellis has two main [playbooks](http://docs.ansible.com/ansible/playbooks.html): `dev.yml` and `server.yml`. As mentioned in local development, Vagrant automatically runs the `dev.yml` playbook for us.
+Trellis has two main [playbooks](https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html): `dev.yml` and `server.yml`. As mentioned in local development, Vagrant automatically runs the `dev.yml` playbook for us.
 
 For remote servers, you provision a server via the `server.yml` playbook. This leaves you with a server *prepared* to run a WordPress site, but without the actual codebase yet.
 


### PR DESCRIPTION
the original url is a 404 now because redhat documentation writers hate you