### PR TITLE
Fix spelling: url -> uri

### DIFF
--- a/docs/sage/10.x/compiling-assets.md
+++ b/docs/sage/10.x/compiling-assets.md
@@ -54,7 +54,7 @@ In your PHP, you can make use of the `\Roots\asset()` function, which is what po
 $asset = \Roots\asset('images/example.jpg');
 // The public URI of the asset
 echo $asset;
-echo $asset->url();
+echo $asset->uri();
 
 // The server path of the asset
 echo $asset->path();


### PR DESCRIPTION
The docs don't reflect the name of the actual method: https://github.com/roots/acorn/blob/62bcf0a64b3f3e0baa1e5dc016470824a967026a/src/Roots/Acorn/Assets/Asset/Asset.php#L57-L62