### PR TITLE
Update ssh-keys.md

### DIFF
--- a/docs/trellis/master/ssh-keys.md
+++ b/docs/trellis/master/ssh-keys.md
@@ -148,5 +148,5 @@ The Trellis `ansible.cfg` file enables this SSH agent forwarding with `ssh_args 
 Remember to import your SSH key password into Keychain by running:
 
 ```bash
-$ ssh-add -K
+$ ssh-add --apple-use-keychain
 ```

--- a/docs/trellis/master/ssh-keys.md
+++ b/docs/trellis/master/ssh-keys.md
@@ -145,8 +145,14 @@ The Trellis `ansible.cfg` file enables this SSH agent forwarding with `ssh_args 
 
 ### macOS/OS X users
 
-Remember to import your SSH key password into Keychain by running:
+Remember to import your SSH key password into Keychain. For macOS Monterey (12.0) and later, you should run:
 
 ```bash
 $ ssh-add --apple-use-keychain
+```
+
+For versions prior, you need to run:
+
+```bash
+$ ssh-add -K
 ```


### PR DESCRIPTION
Hi 👋

On latest MacOS version the command `ssh-add -K` is not recommended anymore:

```
julien@LMON0015 trellis % ssh-add -K                  
WARNING: The -K and -A flags are deprecated and have been replaced
         by the --apple-use-keychain and --apple-load-keychain
         flags, respectively.  To suppress this warning, set the
         environment variable APPLE_SSH_ADD_BEHAVIOR as described in
         the ssh-add(1) manual page.
Identity added: /Users/julien/.ssh/id_rsa (/Users/julien/.ssh/id_rsa)
```

The correct command is now `ssh-add --apple-use-keychain` 😇