### PR TITLE
Add example Bedrock .htaccess when doc root can't be changed

### DIFF
--- a/docs/bedrock/master/server-configuration.md
+++ b/docs/bedrock/master/server-configuration.md
@@ -95,7 +95,7 @@ RewriteRule . /index.php [L]
 
 If you're using a [supported WordPress host](deployment.md#supported-wordpress-hosts) such as Kinsta, then contact support and ask them to set your document root to the `web` folder.
 
-> Sometimes you can't change the document root on hosted web server. In this case, you can create an `.htaccess` file at the root of your project with the following content:
+Sometimes you can't change the document root on hosted web server. In this case, you can create an `.htaccess` file at the root of your project with the following content:
 
 ```php
 RewriteEngine on

--- a/docs/bedrock/master/server-configuration.md
+++ b/docs/bedrock/master/server-configuration.md
@@ -94,3 +94,12 @@ RewriteRule . /index.php [L]
 ## Managed WordPress hosts and Bedrock
 
 If you're using a [supported WordPress host](deployment.md#supported-wordpress-hosts) such as Kinsta, then contact support and ask them to set your document root to the `web` folder.
+
+If your host uses Apache web server you may create `.htaccess` file at the root of your project with the following content
+
+```php
+RewriteEngine on
+
+RewriteCond %{REQUEST_URI} !web/
+RewriteRule ^(.*)$ /web/$1 [L]
+```

--- a/docs/bedrock/master/server-configuration.md
+++ b/docs/bedrock/master/server-configuration.md
@@ -95,7 +95,7 @@ RewriteRule . /index.php [L]
 
 If you're using a [supported WordPress host](deployment.md#supported-wordpress-hosts) such as Kinsta, then contact support and ask them to set your document root to the `web` folder.
 
-If your host uses Apache web server you may create `.htaccess` file at the root of your project with the following content
+> Sometimes you can't change the document root on hosted web server. In this case, you can create an `.htaccess` file at the root of your project with the following content:
 
 ```php
 RewriteEngine on


### PR DESCRIPTION
Add few lines with `.htaccess` example file to help to point document root into `web`. Maybe it will help in a situation when you're using web hosting with Apache web server