### PR TITLE
Update adding-linting.md use .eslintrc.cjs since sage is set to module

### DIFF
--- a/sage/adding-linting.md
+++ b/sage/adding-linting.md
@@ -37,7 +37,7 @@ Add `scripts` to `package.json` for better access to linting your scripts and st
 
 Then create new files for `.eslintrc.js`, `.prettierrc`, and `.stylelintrc`.
 
-`.eslintrc.js`:
+`.eslintrc.cjs`:
 
 ```javascript
 module.exports = {

--- a/sage/adding-linting.md
+++ b/sage/adding-linting.md
@@ -35,7 +35,7 @@ Add `scripts` to `package.json` for better access to linting your scripts and st
 ...
 ```
 
-Then create new files for `.eslintrc.js`, `.prettierrc`, and `.stylelintrc`.
+Then create new files for `.eslintrc.cjs`, `.prettierrc`, and `.stylelintrc`.
 
 `.eslintrc.cjs`:
 

--- a/sage/adding-linting.md
+++ b/sage/adding-linting.md
@@ -1,10 +1,11 @@
 ---
-date_modified: 2023-01-27 13:17
+date_modified: 2023-03-12 19:25
 date_published: 2023-01-23 19:40
 description: How to add ESLint, Prettier, and Stylelint to your Sage 10 theme.
 title: Adding ESLint, Prettier, and Stylelint
 authors:
   - ben
+  - chrillep
 ---
 
 # Adding ESLint, Prettier, and Stylelint


### PR DESCRIPTION
as per https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-formats

<strong>JavaScript (ESM)</strong> - use <code>.eslintrc.cjs</code> when running ESLint in JavaScript packages that specify <code>"type":"module"</code> in their <code>package.json</code>. Note that ESLint does not support ESM configuration at this time.

---

relates to https://github.com/roots/bud/pull/2157