### PR TITLE
Add step to remove types from jsconfig.

### DIFF
--- a/sage/replacing-tailwind-with-bootstrap.md
+++ b/sage/replacing-tailwind-with-bootstrap.md
@@ -48,6 +48,12 @@ Open `bud.config.js` from your theme and remove the following lines:
 -      .useTailwindFontSize()
 ```
 
+### 5. Remove tailwind types from `jsconfig.json`
+
+```diff
+-      "@roots/bud-tailwindcss",
+```
+
 ## Adding Bootstrap
 
 ### 1. Install native support for Sass


### PR DESCRIPTION
Before removing this, VS Code shows an error in which it can't import the files (because they were removed in a previous step).