### PR TITLE
Update fonts-setup.md with SASS url() tip

### DIFF
--- a/sage/fonts-setup.md
+++ b/sage/fonts-setup.md
@@ -33,6 +33,10 @@ resources
 
 ## Add the CSS
 
+::: tip `@roots/bud-sass` users will need to modify the following example
+[`url()` imports in SASS behave differently to CSS](https://bud.js.org/extensions/bud-sass#url-imports). We recommend prefixing aliases with a tilde (eg. `url('~@fonts/...')`), and adding your `fonts` directory to [`bud.assets()`](https://bud.js.org/docs/bud.assets).
+:::
+
 You can place the CSS for your web fonts wherever you'd like. We recommend creating a `styles/common/fonts.css` file and then importing it from `app.css` and `editor.css`:
 
 ```css


### PR DESCRIPTION
Users aren't immediately aware of the pitfalls of using `url()` imports in SASS when reading the Sage font setup documentation.

- Added tip to 'Add the CSS' section, highlighting the difference between `url()` imports in SASS vs CSS.
- Also referred to the docs for `bud.assets()` to copy fonts into dist.

See user story from Discourse thread: https://discourse.roots.io/t/cant-embed-woff2-font-in-sage10/25413/5