### PR TITLE
Adjust `add_editor_style` call to use relative path vs URI

### DIFF
--- a/sage/gutenberg.md
+++ b/sage/gutenberg.md
@@ -1,11 +1,12 @@
 ---
-date_modified: 2023-03-13 11:45
+date_modified: 2023-06-05 20:00
 date_published: 2021-10-21 13:21
 description: How to work with Gutenberg, the WordPress block editor, with the Sage starter theme.
 title: Gutenberg
 authors:
   - alwaysblank
   - ben
+  - joshf
   - Log1x
   - strarsis
 ---

--- a/sage/gutenberg.md
+++ b/sage/gutenberg.md
@@ -26,7 +26,7 @@ If you wish to include the `app.css` stylesheet to the block editor, you can do 
 ```php
 add_action('after_setup_theme', function () {
     add_theme_support('editor-styles');
-    add_editor_style(asset('app.css'));
+    add_editor_style(asset('app.css')->relativePath(get_theme_file_path()));
 });
 ```
 


### PR DESCRIPTION
`add_editor_style` needs to receive the stylesheet as a relative path vs remote URI. 

[Additional context](https://core.trac.wordpress.org/ticket/55728#ticket)