### PR TITLE
Update bedrock-with-lando.md

### DIFF
--- a/bedrock/bedrock-with-lando.md
+++ b/bedrock/bedrock-with-lando.md
@@ -29,6 +29,9 @@ name: bedrock
 recipe: wordpress
 config:
   webroot: web
+services:
+  appserver:
+    type: php:8.2 # Bedrock requires PHP >= 8.0
 ```
 
 ## Configure environment variables

--- a/bedrock/bedrock-with-lando.md
+++ b/bedrock/bedrock-with-lando.md
@@ -1,10 +1,11 @@
 ---
-date_modified: 2023-02-19 12:16
+date_modified: 2023-06-04 16:40
 date_published: 2023-02-19 12:16
 description: How to configure Lando, a local development tool, for a Bedrock-based WordPress site.
 title: Bedrock with Lando
 authors:
   - ben
+  - james0r
 ---
 
 # Bedrock with Lando


### PR DESCRIPTION
The example Lando file will fail as it defaults to an unsupported PHP version.