### PR TITLE
Multisite Sub Directory Install Problem: Update bedrock-with-valet.md

### DIFF
--- a/bedrock/bedrock-with-valet.md
+++ b/bedrock/bedrock-with-valet.md
@@ -88,14 +88,14 @@ Config::define('WP_ALLOW_MULTISITE', true);
  */
 Config::define('WP_ALLOW_MULTISITE', true);
 Config::define('MULTISITE', true);
-Config::define('SUBDOMAIN_INSTALL', true);
+Config::define('SUBDOMAIN_INSTALL', false);
 Config::define('DOMAIN_CURRENT_SITE', env('DOMAIN_CURRENT_SITE'));
 Config::define('PATH_CURRENT_SITE', env('PATH_CURRENT_SITE') ?: '/');
 Config::define('SITE_ID_CURRENT_SITE', env('SITE_ID_CURRENT_SITE') ?: 1);
 Config::define('BLOG_ID_CURRENT_SITE', env('BLOG_ID_CURRENT_SITE') ?: 1);
 ```
 
-* Add the Bedrock multisite URL fixer plugin: `composer require roots/multisite-url-fixer`
+* Add the Bedrock multisite URL fixer plugin: `composer require roots/multisite-url-fixer` (Optional)
 
 * * *
 


### PR DESCRIPTION
Fixes the problem with sub-directly installs not working.  Essentially, setting `SUBDOMAIN_INSTALL` to `true` makes WP assume it's a sub-domain setup at all times. Therefore, we make it false in the case of sub directories. Problem solved!

Also, main documentation says `multisite-url-fixer` is optional for sub-directory instances. Add optional to the last line.

