### PR TITLE
add wp-cli as requirement

### DIFF
--- a/acorn/installation.md
+++ b/acorn/installation.md
@@ -47,6 +47,7 @@ Acorn's server requirements are minimal, and mostly come from WordPress and [Lar
 
 - PHP >=8.0
 - WordPress >= 5.4
+- [WP-CLI](https://wp-cli.org/)
 - BCMath PHP Extension
 - Ctype PHP Extension
 - Fileinfo PHP Extension


### PR DESCRIPTION
Add wp-cli as a server requirement to avoid confusion. This recently came up on [discourse](https://discourse.roots.io/t/command-not-found-wp/25688). 