### PR TITLE
Update fonts-setup.md

### DIFF
--- a/sage/fonts-setup.md
+++ b/sage/fonts-setup.md
@@ -47,7 +47,7 @@ Define your `@font-face` in `styles/common/fonts.css`:
   font-family: 'Public Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('@fonts/public-sans-v14-latin-regular.woff2') format('woff2'),
+  src: url('~@fonts/public-sans-v14-latin-regular.woff2') format('woff2'),
 }
 ```
 


### PR DESCRIPTION
Missing tilde (~) before "@fonts/…"  in src, which threw the error below for me. Adding the tilde removed it.

│ Module not found: Error: Can't resolve './common/@fonts/my-font-name.woff2' in │ │ 'resources/styles'