### PR TITLE
Update to `src: url('~@fonts...` in fonts-setup.md

### DIFF
--- a/sage/fonts-setup.md
+++ b/sage/fonts-setup.md
@@ -47,7 +47,7 @@ Define your `@font-face` in `styles/common/fonts.css`:
   font-family: 'Public Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('@fonts/public-sans-v14-latin-regular.woff2') format('woff2'),
+  src: url('~@fonts/public-sans-v14-latin-regular.woff2') format('woff2'),
 }
 ```
 


### PR DESCRIPTION
`src: url('@fonts/FontFile.woff2')` failed for me with error "Module not found: Error: Can't resolve './@fonts/FontFile.woff2' in 'resources/styles'". Per [this forum post](https://discourse.roots.io/t/module-not-found-error-cant-resolve/22272/9), I found prefixing with `~`, which worked for me.

I should say, I am working with `.scss` files, not `.css` as this document references ("Define your @font-face in styles/common/fonts.css:") and I have not tested `~@fonts` with a `.css` file. But I wanted to propose this change nonetheless.

Thanks!