### PR TITLE
Add line to have `app.wpjson` work without Tailwind

### DIFF
--- a/sage/replacing-tailwind-with-bootstrap.md
+++ b/sage/replacing-tailwind-with-bootstrap.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2023-05-16 10:00
+date_modified: 2024-04-24 13:00
 date_published: 2022-02-24 10:25
 description: Sage 10 comes with Tailwind CSS out of the box, but can be replaced with Bootstrap or any other CSS framework.
 title: Replacing Tailwind CSS with Bootstrap
@@ -10,6 +10,7 @@ authors:
   - MWDelaney
   - kellymears
   - talss89
+  - taylorgorman
 ---
 
 # Replacing Tailwind CSS with Bootstrap

--- a/sage/replacing-tailwind-with-bootstrap.md
+++ b/sage/replacing-tailwind-with-bootstrap.md
@@ -50,6 +50,14 @@ Open `bud.config.js` from your theme and remove the following lines:
 -      .useTailwindFontSize()
 ```
 
+And replace with the following line:
+
+```diff
++      .enable()
+```
+
+See [Managing theme.json](https://bud.js.org/extensions/sage/theme.json) in the Bud extension docs for more details.
+
 ### 5. Remove Tailwind types from `jsconfig.json`
 
 ```diff


### PR DESCRIPTION
Per the @roots/sage Bud extension documentation page I've linked, `.enable()` is necessary when `.useTailwind*()` are not present. I had to google around to find out why my `theme.json` stopped generating.

To test this, I
1. Created a fresh roots/sage project
2. Changed a value in `app.wpjson.setSettings()` in `bud.config.js`, ran `yarn build` and saw the change in `theme.json`
3. Removed the three `.useTailwind*()` lines
4. Changed a value in `app.wpjson.setSettings()`, `yarn build`, no change in `theme.json`
5. Added `.enable()`
6. Changed a value in `app.wpjson.setSettings()`, `yarn build`, did see change in `theme.json`

I added the last sentence with the Bud docs link for proof and help, but feel free to remove if you'd rather keep the page shorter and more focused.