### PR TITLE
Update requirements from Laravel 10 to 12

### DIFF
--- a/acorn/installation.md
+++ b/acorn/installation.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2025-03-07 09:00
+date_modified: 2025-04-03 09:00
 date_published: 2021-11-19 11:58
 description: Install Acorn by running `composer require roots/acorn` in the root of your Composer-based WordPress project.
 title: Installing Acorn
@@ -8,6 +8,7 @@ authors:
   - ben
   - csorrentino
   - QWp6t
+  - joshf
 ---
 
 # Installation
@@ -145,8 +146,8 @@ Open `composer.json` and add Acorn's `postAutoloadDump` function to Composer's `
 
 ## Server requirements
 
-Acorn's server requirements are minimal, and mostly come from WordPress and [Laravel 10's requirements](https://laravel.com/docs/10.x/deployment#server-requirements).
+Acorn's server requirements are minimal, and mostly come from WordPress and [Laravel 12's requirements](https://laravel.com/docs/12.x/deployment#server-requirements).
 
-- PHP >=8.2 with extensions: BCMath, Ctype, Fileinfo, JSON, Mbstring, Tokenizer, XML
+- PHP >=8.2 with extensions: Ctype, cURL, DOM, Fileinfo, Filter, Hash, Mbstring, OpenSSL, PCRE, PDO, Session, Tokenizer, XML
 - WordPress >= 5.4
 - [WP-CLI](https://wp-cli.org/)


### PR DESCRIPTION
I just used the full list from 12's docs. I'm not sure Acorn actually requires each one, but to me it makes sense to make the list match when we're shooting them to Laravel's docs.