### PR TITLE
Link to Laravel 12 instead of Laravel 10 in the cache section

### DIFF
--- a/acorn/laravel-cache-alternative-to-wordpress-transients.md
+++ b/acorn/laravel-cache-alternative-to-wordpress-transients.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2023-01-30 17:32
+date_modified: 2025-06-29 20:23
 date_published: 2023-01-30 17:32
 description: Acorn allows you to use Laravel's cache, which can be used as an alternative to the WordPress Transients API.
 title: Laravel Cache as an Alternative to WordPress Transients
@@ -11,10 +11,10 @@ authors:
 
 Acorn provides [Laravel integration with WordPress](/acorn/), which means that certain Laravel components are able to be used within your WordPress site.
 
-Compared to WordPress transients API, [Laravel Cache](https://laravel.com/docs/10.x/cache) provides a more standardized and developer-friendly approach to caching data. It also has a wider range of cache storage options, compared to the WordPress Transients API, which only supports storing data in the WordPress database.
+Compared to WordPress transients API, [Laravel Cache](https://laravel.com/docs/12.x/cache) provides a more standardized and developer-friendly approach to caching data. It also has a wider range of cache storage options, compared to the WordPress Transients API, which only supports storing data in the WordPress database.
 
 ::: tip
-Review the [Laravel Cache docs](https://laravel.com/docs/10.x/cache) to get a more detailed understanding about how it works, along with the various ways that the cache can be configured
+Review the [Laravel Cache docs](https://laravel.com/docs/12.x/cache) to get a more detailed understanding about how it works, along with the various ways that the cache can be configured
 :::
 
 ## Storing data in the cache

--- a/acorn/logging.md
+++ b/acorn/logging.md
@@ -10,7 +10,7 @@ authors:
 # Logging
 
 ::: tip
-We recommend referencing the [Laravel docs on Logging](https://laravel.com/docs/10.x/logging)
+We recommend referencing the [Laravel docs on Logging](https://laravel.com/docs/12.x/logging)
 :::
 
 The location of your application logs depends on your [directory structure](/acorn/docs/directory-structure/).


### PR DESCRIPTION
Hello!

Unless I'm missing something, the link should lead to Laravel Cache 12 instead of Laravel Cache 10. This fixes that!

I was uncertain about the timezone for "date_modified" so I just used my own. Not like it matters when you accept this PR next week, right?