### PR TITLE
Change image URL syntax in CSS to use Vite alias

### DIFF
--- a/sage/compiling-assets.md
+++ b/sage/compiling-assets.md
@@ -45,11 +45,11 @@ Use the [`Vite::asset` method](https://laravel.com/docs/12.x/vite#blade-processi
 
 ### Assets in CSS
 
-CSS files and images are sibling folders, so you can reference images in CSS:
+You can reference images in CSS using the included Vite alias for images.
 
 ```css
 .background {
-  background-image: url("../images/example.svg");
+  background-image: url("@images/example.svg");
 }
 ```
 

--- a/sage/compiling-assets.md
+++ b/sage/compiling-assets.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2025-02-27 13:40
+date_modified: 2025-12-11 11:00
 date_published: 2015-09-01 18:19
 description: Sage uses Vite for fast asset compilation with HMR support. Includes custom plugin for hot module replacement in WordPress block editor during development.
 title: Compiling Assets in Sage with Vite
@@ -8,6 +8,7 @@ authors:
   - ben
   - kero
   - Log1x
+  - octoxan
   - toddsantoro
 ---
 


### PR DESCRIPTION
Updated image syntax recommendation in CSS to use the already included Vite alias for maximum compatibility. The current method "../images" results in 404s since the CSS file references the normal file name and the image that gets moved into the build directory has a hashed name like example-ta6m7nBe.jpg.

In the vite.config.js Sage ships with, it already includes an `alias` block, this takes advantage of that to ensure CSS always points to the image correctly, whether using a standard local or a cloud development environment.