### PR TITLE
Fix for textdomains not being loaded since WordPress 6.7

### DIFF
--- a/sage/localization.md
+++ b/sage/localization.md
@@ -26,7 +26,11 @@ Add the following to `app/setup.php`:
 
 ```php
 add_action('after_setup_theme', function () {
-    load_theme_textdomain('sage', get_template_directory() . '/resources/lang');
+    if ( version_compare( $GLOBALS['wp_version'], '6.7', '<' ) ) {
+        load_theme_textdomain( 'sage', get_template_directory() . '/resources/lang' );
+    } else {
+        load_textdomain( 'sage', get_template_directory() . '/resources/lang/' . determine_locale() . '.mo' );
+    }
 });
 ```
 

--- a/sage/localization.md
+++ b/sage/localization.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2023-06-01 10:20
+date_modified: 2025-12-22 13:00
 date_published: 2018-04-24 09:47
 description: Generate translation files for Sage themes with custom build scripts. Create and load language files for multilingual WordPress sites with proper loading.
 title: Localizing the Sage WordPress Theme

--- a/sage/localization.md
+++ b/sage/localization.md
@@ -26,11 +26,7 @@ Add the following to `app/setup.php`:
 
 ```php
 add_action('after_setup_theme', function () {
-    if ( version_compare( $GLOBALS['wp_version'], '6.7', '<' ) ) {
-        load_theme_textdomain( 'sage', get_template_directory() . '/resources/lang' );
-    } else {
-        load_textdomain( 'sage', get_template_directory() . '/resources/lang/' . determine_locale() . '.mo' );
-    }
+    load_textdomain( 'sage', get_template_directory() . '/resources/lang/' . determine_locale() . '.mo' );
 });
 ```
 


### PR DESCRIPTION
Introduced with WordPress 6.7, the currently documented way of loading the textdomain is not working anymore. This PR changes the docs to call the right function depending on the used WordPress version.