### PR TITLE
Add example for Blade support in blocks using `block.json` with `render` field

### DIFF
--- a/acorn/rendering-blade-views.md
+++ b/acorn/rendering-blade-views.md
@@ -57,6 +57,30 @@ add_filter('register_block_type_args', function ($args, $name) {
 }, 10, 2);
 ```
 
+### block.json `render` field with Blade templates
+
+If you're registering blocks using `block.json` with a `render` field pointing to a Blade template (e.g. `"render": "file:./render.blade.php"`), you can automatically handle the rendering with a single filter:
+```
+add_filter('register_block_type_args', function (array $args, string $name): array {
+    if (empty($args['render_callback']) || ! ($args['render_callback'] instanceof \Closure)) {
+        return $args;
+    }
+
+    $reflector = new \ReflectionFunction($args['render_callback']);
+    $renderCallbackVariables = $reflector->getStaticVariables();
+    
+    if (array_key_exists('template_path', $renderCallbackVariables) && str_ends_with($renderCallbackVariables['template_path'], '.blade.php')) {
+        $args['render_callback'] = function ($attributes, $content, $block) use ($renderCallbackVariables) {
+            return view()
+                ->file($renderCallbackVariables['template_path'], compact('attributes', 'content', 'block'))
+                ->render();
+        };
+    }
+
+    return $args;
+}, 1, 2);
+```
+
 ## Rendering emails with Blade templates
 
 The following example uses the `resources/views/emails/welcome.blade.php` template file customizing the new WordPress user notification emails:

--- a/acorn/rendering-blade-views.md
+++ b/acorn/rendering-blade-views.md
@@ -60,7 +60,7 @@ add_filter('register_block_type_args', function ($args, $name) {
 ### block.json `render` field with Blade templates
 
 If you're registering blocks using `block.json` with a `render` field pointing to a Blade template (e.g. `"render": "file:./render.blade.php"`), you can automatically handle the rendering with a single filter:
-```
+```php
 add_filter('register_block_type_args', function (array $args, string $name): array {
     if (empty($args['render_callback']) || ! ($args['render_callback'] instanceof \Closure)) {
         return $args;

--- a/acorn/rendering-blade-views.md
+++ b/acorn/rendering-blade-views.md
@@ -1,11 +1,12 @@
 ---
-date_modified: 2023-04-03 13:18
+date_modified: 2026-02-02 12:00
 date_published: 2023-02-21 11:30
 description: Render Blade templates anywhere in WordPress using the `view()` helper function. Examples for Gutenberg blocks, ACF blocks, and email notifications.
 title: Rendering Blade Views in WordPress
 authors:
   - ben
   - chuckienorton
+  - rafaucau
   - strarsis
   - talss89
 ---
@@ -60,6 +61,7 @@ add_filter('register_block_type_args', function ($args, $name) {
 ### block.json `render` field with Blade templates
 
 If you're registering blocks using `block.json` with a `render` field pointing to a Blade template (e.g. `"render": "file:./render.blade.php"`), you can automatically handle the rendering with a single filter:
+
 ```php
 add_filter('register_block_type_args', function (array $args, string $name): array {
     if (empty($args['render_callback']) || ! ($args['render_callback'] instanceof \Closure)) {


### PR DESCRIPTION
Added a section on using the `render` field in `block.json` for Blade templates.