### PR TITLE
Revise Memcached Object Cache installation instructions

### DIFF
--- a/trellis/redis.md
+++ b/trellis/redis.md
@@ -105,9 +105,28 @@ wp redis enable
 
 Install a Memcached object cache plugin:
 
-1. **Memcached Object Cache**: [https://wordpress.org/plugins/memcached/](https://wordpress.org/plugins/memcached/)
+1. **Memcached Object Cache**: [automattic/wp-memcached](https://github.com/Automattic/wp-memcached)
 
-Memcached Object Cache is a drop-in plugin. Follow the README's instructions for installation.
+```bash
+# `reference` and `url` must be pinned to the same commit or tag
+# Do not reference to a branch
+#
+# For a different commit or tag, inspect that revision's `composer.json` in the
+# `automattic/wp-memcached` repository and copy its `require` section here so the
+# requirements match the version you're pinning
+# Replace `composer/installers` with `"koodimonni/composer-dropin-installer":"^1.4"`
+composer repo add wp-memcached '{"type":"package","package":{"name":"automattic/wp-memcached","type":"wordpress-dropin","version":"dev-master","dist":{"type":"file","url":"https://raw.githubusercontent.com/Automattic/wp-memcached/bb3b9f689dd99df66454b93ece34093556dc37f9/object-cache.php","reference":"bb3b9f689dd99df66454b93ece34093556dc37f9"},"require":{"koodimonni/composer-dropin-installer":"^1.4","php":">=7.4.0","ext-memcache":"*"}}}' --before wpackagist
+
+# Configure the install location
+composer config allow-plugins.koodimonni/composer-dropin-installer true
+composer config --json extra.dropin-paths '{"web/app/":["type:wordpress-dropin"]}'
+
+# Omit `--ignore-platform-req=ext-memcache` if already installed
+composer require automattic/wp-memcached:dev-master --ignore-platform-req=ext-memcache
+
+# Untrack the plugin because it is now managed by Composer
+echo 'web/app/object-cache.php' >> .gitignore
+```
 
 ## Configuration Examples
 

--- a/trellis/redis.md
+++ b/trellis/redis.md
@@ -1,10 +1,11 @@
 ---
-date_modified: 2026-02-16 13:00
+date_modified: 2026-02-20 20:00
 date_published: 2025-10-24 12:00
 description: Enable Redis in Trellis for WordPress object caching. Improve site performance by caching database queries and reducing load on MySQL database servers.
 title: Redis Object Caching for WordPress in Trellis
 authors:
   - ben
+  - TangRufus
 ---
 
 # Redis Object Caching for WordPress in Trellis


### PR DESCRIPTION
Follow up on https://discourse.roots.io/t/questions-about-enabling-the-object-cache-using-memcached/30124 and https://github.com/roots/docs/commit/a2f16a13ae79c3dcdbcad0ba0af2ccbcab0c795b

Suggest a way to manage `Memcached Object Cache` via composer.

1. Using [automattic/wp-memcached](https://github.com/automattic/wp-memcached) instead of `wpackagist-plugin/memcached` because the wp.org one hasn't be sync-ed / tagged since July 2021.
2. Using a custom package definition in Bedrock's `composer.json` because [`automattic/wp-memcached` identities itself as a `wordpress-plugin`](https://github.com/Automattic/wp-memcached/blob/bb3b9f689dd99df66454b93ece34093556dc37f9/composer.json#L5)  where it isn't.
3. Using [`koodimonni/composer-dropin-installer`](https://github.com/Koodimonni/Composer-Dropin-Installer) because despite [`composer/installers` mentions support for `wordpress-dropin`](https://github.com/composer/installers/pull/265) I couldn't get it installed at `web/app/object-cache.php`

### Discussion

Given the infrequent development on `automattic/wp-memcached`, users might be better off manually copy-and-paste & git commit the `object-cache.php` instead.

Or, we *could* make a composer repo for `automattic/wp-memcached` and other dropin plugins. Like the one with did for `roots/wordpress-no-content`.