### PR TITLE
Add CI lint for single-command bash blocks

### DIFF
--- a/.github/workflows/lint-bash-blocks.yml
+++ b/.github/workflows/lint-bash-blocks.yml
@@ -27,7 +27,7 @@ jobs:
               }
               in_block && /^[^#]/ && !/^[[:space:]]*$/ { lines++ }
             ' "$file"
-          done < <(find . -name '*.md' -not -path './.git/*')
+          done < <(find . -name '*.md' -not -path './.git/*' -not -name 'CLAUDE.md')
 
           # Run again to set exit code
           fail=0
@@ -41,7 +41,7 @@ jobs:
               in_block && /^[^#]/ && !/^[[:space:]]*$/ { lines++ }
               END { if (found) exit 1 }
             ' "$file" || fail=1
-          done < <(find . -name '*.md' -not -path './.git/*')
+          done < <(find . -name '*.md' -not -path './.git/*' -not -name 'CLAUDE.md')
 
           if [ "$fail" -eq 1 ]; then
             echo ""

--- a/.github/workflows/lint-bash-blocks.yml
+++ b/.github/workflows/lint-bash-blocks.yml
@@ -1,0 +1,53 @@
+name: Lint bash code blocks
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+
+jobs:
+  check-bash-blocks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for multi-line bash code blocks
+        run: |
+          status=0
+          while IFS= read -r file; do
+            # Extract bash code blocks and check for multiple non-empty lines
+            awk '
+              /^```bash/ { in_block=1; lines=0; start=NR; next }
+              /^```/ && in_block {
+                if (lines > 1) {
+                  printf "::error file=%s,line=%d::%s\n", FILENAME, start, "Bash code block has multiple commands. Each block must contain exactly one command."
+                  found=1
+                }
+                in_block=0; next
+              }
+              in_block && /^[^#]/ && !/^[[:space:]]*$/ { lines++ }
+            ' "$file"
+          done < <(find . -name '*.md' -not -path './.git/*')
+
+          # Run again to set exit code
+          fail=0
+          while IFS= read -r file; do
+            awk '
+              /^```bash/ { in_block=1; lines=0; next }
+              /^```/ && in_block {
+                if (lines > 1) { found=1 }
+                in_block=0; next
+              }
+              in_block && /^[^#]/ && !/^[[:space:]]*$/ { lines++ }
+              END { if (found) exit 1 }
+            ' "$file" || fail=1
+          done < <(find . -name '*.md' -not -path './.git/*')
+
+          if [ "$fail" -eq 1 ]; then
+            echo ""
+            echo "Error: Found bash code blocks with multiple commands."
+            echo "Each bash code block must contain exactly one command."
+            exit 1
+          fi
+
+          echo "All bash code blocks contain a single command."

--- a/.github/workflows/lint-bash-blocks.yml
+++ b/.github/workflows/lint-bash-blocks.yml
@@ -13,29 +13,17 @@ jobs:
 
       - name: Check for multi-line bash code blocks
         run: |
-          status=0
+          fail=0
           while IFS= read -r file; do
-            # Extract bash code blocks and check for multiple non-empty lines
-            awk '
+            # Strip leading ./ so GitHub annotations link to the correct file
+            clean="${file#./}"
+            awk -v file="$clean" '
               /^```bash/ { in_block=1; lines=0; start=NR; next }
               /^```/ && in_block {
                 if (lines > 1) {
-                  printf "::error file=%s,line=%d::%s\n", FILENAME, start, "Bash code block has multiple commands. Each block must contain exactly one command."
+                  printf "::error file=%s,line=%d::Bash code block has multiple commands. Each block must contain exactly one command.\n", file, start
                   found=1
                 }
-                in_block=0; next
-              }
-              in_block && /^[^#]/ && !/^[[:space:]]*$/ { lines++ }
-            ' "$file"
-          done < <(find . -name '*.md' -not -path './.git/*' -not -name 'CLAUDE.md')
-
-          # Run again to set exit code
-          fail=0
-          while IFS= read -r file; do
-            awk '
-              /^```bash/ { in_block=1; lines=0; next }
-              /^```/ && in_block {
-                if (lines > 1) { found=1 }
                 in_block=0; next
               }
               in_block && /^[^#]/ && !/^[[:space:]]*$/ { lines++ }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# Docs Conventions
+
+## Markdown bash code blocks
+
+Each bash code block must contain exactly one command. Never combine multiple commands in a single block. On the roots.io front-end, bash code blocks have a clipboard copy button that only supports single lines.
+
+Good:
+
+````markdown
+```bash
+composer require example/package
+```
+
+```bash
+wp plugin activate example
+```
+````
+
+Bad:
+
+````markdown
+```bash
+composer require example/package
+wp plugin activate example
+```
+````

--- a/bedrock/converting-wordpress-sites-to-bedrock.md
+++ b/bedrock/converting-wordpress-sites-to-bedrock.md
@@ -28,6 +28,9 @@ Create a new Bedrock installation:
 
 ```bash
 $ composer create-project roots/bedrock example.com
+```
+
+```bash
 $ cd example.com
 ```
 
@@ -65,6 +68,9 @@ Activate Lithify and run the conversion command:
 
 ```bash
 $ wp plugin activate lithify
+```
+
+```bash
 $ wp lithify
 ```
 

--- a/test-lint.md
+++ b/test-lint.md
@@ -1,0 +1,6 @@
+# Test file for bash block linter
+
+```bash
+echo "first"
+echo "second"
+```

--- a/test-lint.md
+++ b/test-lint.md
@@ -1,6 +1,0 @@
-# Test file for bash block linter
-
-```bash
-echo "first"
-echo "second"
-```

--- a/trellis/redis.md
+++ b/trellis/redis.md
@@ -309,13 +309,17 @@ This setup uses three different cache systems:
 Monitor Redis usage:
 
 ```bash
-# Redis CLI
 redis-cli
+```
 
-# Inside Redis CLI
-INFO memory
-INFO stats
+```bash
+redis-cli INFO memory
+```
 
-# Monitor real-time commands
+```bash
+redis-cli INFO stats
+```
+
+```bash
 redis-cli MONITOR
 ```


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with convention that bash code blocks must contain exactly one command (the roots.io front-end Markdown rendering only supports single lines for our clipboard copy functionality, and to account for bash blocks with and without `$` prefixes)
- Adds a GitHub Action that checks all markdown files on PRs and fails if any bash block has multiple commands

<img width="863" height="363" alt="image" src="https://github.com/user-attachments/assets/fa1e90fc-825e-46e7-b39f-77db61056d4d" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)