### PR TITLE
Update Trellis docs for HTTP/3 support

### DIFF
--- a/trellis/installation.md
+++ b/trellis/installation.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2024-09-11 10:00
+date_modified: 2026-03-06 13:00
 date_published: 2015-10-15 12:20
 description: Install Trellis for WordPress projects. Complete setup instructions covering requirements, dependencies, project initialization, and initial configuration.
 title: Installing Trellis for WordPress
@@ -90,7 +90,7 @@ with a single command thanks to trellis-cli too.
 Trellis provisions a base Ubuntu 24.04 server by installing and configuring the following software:
 
 * PHP 8.3+
-* Nginx (including HTTP2/ and optional FastCGI micro-caching)
+* Nginx (including HTTP/2, HTTP/3, and optional FastCGI micro-caching)
 * MariaDB (a drop-in MySQL replacement)
 * SSL support (scores an A+ on the [Qualys SSL Server Test](https://www.ssllabs.com/ssltest/))
 * Let's Encrypt for free SSL certificates

--- a/trellis/ssl.md
+++ b/trellis/ssl.md
@@ -373,6 +373,8 @@ Our HTTPS implementation uses all performance optimizations possible to ensure y
 - 1400 byte TLS records
 - Longer keepalives
 
+HTTP/3 requires UDP port 443 to be open. If you have a cloud or hardware firewall in front of your server (eg: AWS security groups, DigitalOcean cloud firewalls), ensure it allows UDP/443 inbound traffic.
+
 See [Is TLS Fast Yet?](https://istlsfastyet.com/) for more information on fast TLS/SSL.
 
 ## Browser support

--- a/trellis/ssl.md
+++ b/trellis/ssl.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2025-11-24 13:00
+date_modified: 2026-03-06 13:00
 date_published: 2015-09-06 07:42
 description: Enable HTTPS in Trellis with automatic Let's Encrypt certificates, manually provided SSL certificates, or self-signed certificates for local development.
 title: SSL Certificates in Trellis
@@ -367,7 +367,7 @@ example.com:
 
 Our HTTPS implementation uses all performance optimizations possible to ensure your sites remain fast despite the small overhead of SSL. This includes the following features:
 
-- HTTP/2 support (fallback to HTTP/1.1 for older browsers)
+- HTTP/3 support with QUIC (fallback to HTTP/2 and HTTP/1.1 for older browsers)
 - SSL session cache
 - OCSP stapling
 - 1400 byte TLS records


### PR DESCRIPTION
## Summary

- Update Nginx feature description to include HTTP/3 in `installation.md`
- Update SSL performance section to mention HTTP/3 with QUIC in `ssl.md`

Docs updates for https://github.com/roots/trellis/pull/1531 — merge after that PR is merged and a new Trellis version is tagged.