### PR TITLE
Update Bedrock minimum PHP requirement to 8.3

### DIFF
--- a/bedrock/bedrock-with-lando.md
+++ b/bedrock/bedrock-with-lando.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2023-06-04 16:40
+date_modified: 2026-03-08 10:00
 date_published: 2023-02-19 12:16
 description: Set up Lando for Bedrock WordPress development. Configure webroot to `web/` directory and adjust Lando settings for Bedrock's unique folder structure.
 title: Bedrock Local Development with Lando
@@ -32,7 +32,7 @@ config:
   webroot: web
 services:
   appserver:
-    type: php:8.2 # Bedrock requires PHP >= 8.0
+    type: php:8.3 # Bedrock requires PHP >= 8.3
 ```
 
 ## Configure environment variables

--- a/bedrock/installation.md
+++ b/bedrock/installation.md
@@ -1,7 +1,7 @@
 ---
-date_modified: 2025-04-16 10:45
+date_modified: 2026-03-08 10:00
 date_published: 2015-10-15 12:29
-description: Install Bedrock with PHP 8.1+ and Composer. Configure environment variables in `.env` file and set document root to `web/` directory to access WordPress.
+description: Install Bedrock with PHP 8.3+ and Composer. Configure environment variables in `.env` file and set document root to `web/` directory to access WordPress.
 title: Installing the Bedrock WordPress Boilerplate
 authors:
   - ben
@@ -25,7 +25,7 @@ Bedrock is a [WordPress boilerplate](https://roots.io/bedrock/).
 
 ## Requirements
 
-- PHP >= 8.1
+- PHP >= 8.3
 - [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos)
 
 ## Installing Bedrock with Composer

--- a/bedrock/server-configuration.md
+++ b/bedrock/server-configuration.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2025-10-03 09:00
+date_modified: 2026-03-08 10:00
 date_published: 2018-12-21 18:24
 description: Configure Nginx or Apache for Bedrock by setting document root to `web/` directory. Includes complete server configuration examples and rewrite rules.
 title: Server Configuration for Bedrock
@@ -12,7 +12,7 @@ authors:
 
 # Server Configuration for Bedrock
 
-Bedrock can run on any webserver that supports Composer and PHP >= 8.1. The document root for your site must be pointed to Bedrock's `web` folder.
+Bedrock can run on any webserver that supports Composer and PHP >= 8.3. The document root for your site must be pointed to Bedrock's `web` folder.
 
 ## Nginx configuration for Bedrock
 


### PR DESCRIPTION
## Summary
- Update minimum PHP requirement from 8.1 to 8.3 across Bedrock docs
- Updated in installation, server configuration, and Lando setup pages
- Updated SEO descriptions and date_modified frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)