### PR TITLE
Trellis: server commands and Hetzner Cloud docs

### DIFF
--- a/trellis/cli.md
+++ b/trellis/cli.md
@@ -13,7 +13,7 @@ trellis-cli is a command-line interface (CLI) to manage Trellis projects via the
 
 * Automatic Python Virtualenv integration for easier dependency management
 * Smart autocompletion (based on your defined environments and sites)
-* One-command DigitalOcean droplet creation
+* One-command cloud server creation (DigitalOcean, Hetzner Cloud)
 * Better Ansible Vault support for encrypting files
 * (New) Built-in virtual machine support for development environments
 
@@ -82,21 +82,22 @@ For subcommand documentation, run `trellis <command> -h`.
 | Command | Description |
 | --- | --- |
 | `alias` | Generate WP CLI aliases for remote environments |
-| `check` | Checks if Trellis requirements are met |
+| `check` | Checks if the required and optional Trellis dependencies are installed |
 | `db` | Commands for database management |
 | `deploy` | Deploys a site to the specified environment |
 | `dotenv` | Template .env files to local system |
-| `droplet` | Commands for DigitalOcean Droplets |
+| `server` | Commands for cloud server management (DigitalOcean, Hetzner Cloud) |
 | `exec` | Exec runs a command in the Trellis virtualenv |
 | `galaxy` | Commands for Ansible Galaxy |
 | `info` | Displays information about this Trellis project |
 | `init` | Initializes an existing Trellis project |
 | `key` | Commands for managing SSH keys |
-| `logs` | Tails the Nginx log files |
+| `logs` | Tails the Nginx log files for an environment |
 | `new` | Creates a new Trellis project |
 | `open` | Opens user-defined URLs (and more) which can act as shortcuts/bookmarks specific to your Trellis projects |
 | `provision` | Provisions the specified environment |
-| `rollback` | Rollsback the last deploy of the site on the specified environment |
+| `rollback` | Rollback the last deploy of the site on the specified environment |
+| `shell-init` | Prints a script which can be eval'd to set up Trellis' virtualenv integration in various shells |
 | `ssh` | Connects to host via SSH |
 | `valet` | Commands for Laravel Valet |
 | `vault` | Commands for Ansible Vault |
@@ -137,7 +138,13 @@ Current supported settings:
 | `load_plugins` | Load external CLI plugins | boolean | true |
 | `open` | List of name -> URL shortcuts | map[string]string | none |
 | `virtualenv_integration` | Enable automated virtualenv integration | boolean | true |
+| `server` | Options for cloud server management | Object | see below |
 | `vm` | Options for dev virtual machines | Object | see below |
+
+### `server`
+| Setting | Description | Type | Default |
+| --- | --- | -- | -- |
+| `provider` | Cloud provider (Options: `digitalocean`, `hetzner`)| string | `digitalocean` |
 
 ### `vm`
 | Setting | Description | Type | Default |
@@ -162,6 +169,8 @@ load_plugins: true
 open:
   site: "https://mysite.com"
   admin: "https://mysite.com/wp/wp-admin"
+server:
+  provider: digitalocean
 virtualenv_integration: true
 vm:
   manager: auto

--- a/trellis/deploy-to-digitalocean.md
+++ b/trellis/deploy-to-digitalocean.md
@@ -1,7 +1,7 @@
 ---
-date_modified: 2023-01-27 13:17
+date_modified: 2026-04-03 10:00
 date_published: 2019-01-07 10:05
-description: Deploy Trellis WordPress sites to DigitalOcean servers. Set up droplets, configure server settings, and automate WordPress deployment to DigitalOcean.
+description: Deploy Trellis WordPress sites to DigitalOcean servers. Create servers, configure settings, and automate WordPress deployment to DigitalOcean.
 title: Deploying Trellis to DigitalOcean
 authors:
   - ben
@@ -9,20 +9,20 @@ authors:
 
 # Deploying Trellis to DigitalOcean
 
-[DigitalOcean](https://roots.io/r/digitalocean) is a cloud infrastructure provider that offers virtual servers called droplets starting at $5/month that can handle most normal WordPress sites when provisioned with Trellis.
+[DigitalOcean](https://roots.io/r/digitalocean) is a cloud infrastructure provider that offers virtual servers (droplets) that can handle most normal WordPress sites when provisioned with Trellis.
 
-To provision a server, Trellis requires a server running a bare/stock version of the latest Ubuntu LTS release.
+To provision a server, Trellis requires a server running a bare/stock version of Ubuntu 24.04 LTS.
 
 ::: tip
 ℹ️ If you [signup for DigitalOcean](https://roots.io/r/digitalocean) through the Roots referral link you will receive a free $200 in credit for 2 months, and you help cover the costs of our hosting.
 ::: 
 
-## Creating a new DigitalOcean droplet
+## Creating a new server
 
-Trellis CLI comes with a `trellis droplet create` command to automatically create a DigitalOcean droplet for a specified environment:
+Trellis CLI comes with a `trellis server create` command to automatically create and provision a server for a specified environment:
 
 ```shell
-$ trellis droplet create production
+$ trellis server create production
 ```
 
 ::: warning
@@ -31,31 +31,38 @@ This command requires a [DigitalOcean personal access token](https://cloud.digit
 
 If the `DIGITALOCEAN_ACCESS_TOKEN` environment variable is not set, the command will prompt for one.
 
+DigitalOcean is the default provider. You can also set it explicitly with the `--provider` flag or in your `trellis.cli.yml`:
+
+```yaml
+server:
+  provider: digitalocean
+```
+
 ### Quick start (region and size will be prompted)
 
 ```shell
-$ trellis droplet create production
+$ trellis server create production
 ```
 
-![Screenshot of trellis droplet create example](https://cdn.roots.io/app/uploads/deploy-to-digitalocean-trellis-droplet-create.png)
+![Screenshot of trellis server create example](https://cdn.roots.io/app/uploads/deploy-to-digitalocean-trellis-droplet-create.png)
 
-The remote server playbook will run and provision your droplet with PHP, Nginx, and everything else included in Trellis.
+The remote server playbook will run and provision your server with PHP, Nginx, and everything else included in Trellis.
 
 ### Additional options
 
 The command help file can be accessed by passing the `--help` flag:
 
 ```shell
-$ trellis droplet create --help
+$ trellis server create --help
 ```
 
 <details>
-<summary>trellis droplet create --help</summary>
+<summary>trellis server create --help</summary>
 
 ```plaintext
-Usage: trellis droplet create [options] ENVIRONMENT
+Usage: trellis server create [options] ENVIRONMENT
 
-Creates a droplet (server) on DigitalOcean for the environment specified.
+Creates a server on a cloud provider for the environment specified.
 
 Only remote servers (for staging and production) are currently supported.
 
@@ -67,29 +74,26 @@ will prompt for one.
 
 Create a production server (region and size will be prompted):
 
-  $ trellis droplet create production
+  $ trellis server create production
 
 Create a 1gb server in the nyc3 region:
 
-  $ trellis droplet create --region=nyc3 --size=s-1vcpu-1gb production
-
-Create a 1gb server with a specific Ubuntu image:
-
-  $ trellis droplet create --region=nyc3 --image=ubuntu-18-04-x64 --size=s-1vcpu-1gb production
+  $ trellis server create --region=nyc3 --size=s-1vcpu-1gb production
 
 Create a server but skip provisioning:
 
-  $ trellis droplet create --skip-provision production
+  $ trellis server create --skip-provision production
 
 Arguments:
   ENVIRONMENT Name of environment (ie: production)
 
 Options:
+      --provider        Cloud provider (digitalocean, hetzner)
       --region          Region to create the server in
-      --image           (default: ubuntu-20-04-x64) Server image (ie: Linux distribution)
+      --image           (default: ubuntu-24-04-x64) Server image (ie: Linux distribution)
       --size            Server size/type
       --skip-provision  Skip provision after server is created
-      --ssh-key         (default: ~/.ssh/id_rsa.pub) path to SSH public key to be added on the server
+      --ssh-key         Path to SSH public key to be added on the server
   -h, --help            show this help
 ```
 
@@ -97,7 +101,7 @@ Options:
 
 ## Changes made after running the command
 
-After creating a new droplet, your local project will have a modified hosts file for the environment that you provisioned:
+After creating a new server, your local project will have a modified hosts file for the environment that you provisioned:
 
 ```diff
 [production]
@@ -109,7 +113,7 @@ After creating a new droplet, your local project will have a modified hosts file
 +159.89.191.207
 ```
 
-## Deploying to DigitalOcean droplet
+## Deploying
 
 Once your server is provisioned you’ll want to perform the first deploy. If you try to visit your site before deploying you’ll see a server 500 error.
 
@@ -119,9 +123,9 @@ $ trellis deploy production
 
 After the first deploy is done, you can now either install WordPress by visiting the site or even import an existing database.
 
-## $5 droplet performance
+## Performance
 
-If you enable the [FastCGI caching in Trellis](/trellis/docs/fastcgi-caching/) then you’ll be able to squeeze quite a bit of performance out of a $5 DigitalOcean droplet.
+If you enable the [FastCGI caching in Trellis](/trellis/docs/fastcgi-caching/) then you’ll be able to squeeze quite a bit of performance out of a small DigitalOcean droplet.
 
 <p><iframe src="https://share.loader.io/reports/19a5726e5f296a96c431f8609dd427cd/widget/results/6ebcd76c5963361fc0acf413364709e1" frameborder="0" style="width: 100%; height: 300px;"></iframe></p>
 <p><a href="http://loader.io/reports/19a5726e5f296a96c431f8609dd427cd/results/6ebcd76c5963361fc0acf413364709e1">View on loader.io</a></p>

--- a/trellis/remote-server-setup.md
+++ b/trellis/remote-server-setup.md
@@ -15,7 +15,26 @@ authors:
 
 # Remote Server Setup for WordPress with Trellis
 
-Trellis can be used for setting up remote servers (offered by VPS/cloud service providers such as [DigitalOcean](/trellis/docs/deploy-to-digitalocean/)) to host your staging and production environments.
+Trellis can be used for setting up remote servers (offered by VPS/cloud service providers such as [DigitalOcean](/trellis/docs/deploy-to-digitalocean/) and [Hetzner Cloud](https://hetzner.cloud/?ref=V6DnI7GDHM4N)) to host your staging and production environments.
+
+::: tip
+ℹ️ Sign up for [Hetzner Cloud](https://hetzner.cloud/?ref=V6DnI7GDHM4N) through the Roots referral link to receive $20 in cloud credits.
+:::
+
+Trellis CLI includes a `trellis server create` command that can automatically create and provision a server on a supported cloud provider:
+
+```shell
+$ trellis server create production
+```
+
+This command requires a cloud provider API token. If the token environment variable is not set, the command will prompt for one.
+
+| Provider | Environment Variable | Token Link |
+| --- | --- | --- |
+| DigitalOcean | `DIGITALOCEAN_ACCESS_TOKEN` | [Create a DigitalOcean token](https://cloud.digitalocean.com/account/api/tokens/new) |
+| Hetzner Cloud | `HCLOUD_TOKEN` | [Create a Hetzner API token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/) |
+
+See the [CLI docs](/trellis/docs/cli/) for more details on configuring your cloud provider.
 
 ::: warning
 **Trellis cannot provision shared or managed hosts.** Trellis requires a bare server if you want to use it for provisioning.


### PR DESCRIPTION
## Summary
- Replace deprecated `droplet` references with new `server` commands
- Add Hetzner Cloud as a supported provider with referral link and API token docs
- Add `server.provider` config option and `shell-init` command to CLI docs
- Fix stale command descriptions and `rollback` typo

🤖 Generated with [Claude Code](https://claude.com/claude-code)