### PR TITLE
Ubuntu 26.04

### DIFF
--- a/trellis/cli.md
+++ b/trellis/cli.md
@@ -150,7 +150,7 @@ Current supported settings:
 | Setting | Description | Type | Default |
 | --- | --- | -- | -- |
 | `manager` | VM manager (Options: `auto` (depends on OS), `lima`)| string | "auto" |
-| `ubuntu` | Ubuntu OS version (Options: `18.04`, `20.04`, `22.04`, `24.04`)| string | `24.04` |
+| `ubuntu` | Ubuntu OS version (Options: `22.04`, `24.04`, `26.04`)| string | `26.04` |
 | `hosts_resolver` | VM hosts resolver (Options: `hosts_file`)| string | `hosts_file` |
 | `images` | Custom OS image | object | Set based on `ubuntu` version |
 
@@ -174,7 +174,7 @@ server:
 virtualenv_integration: true
 vm:
   manager: auto
-  ubuntu: 24.04
+  ubuntu: 26.04
 ```
 
 Example env var usage:

--- a/trellis/deploy-to-digitalocean.md
+++ b/trellis/deploy-to-digitalocean.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2026-04-03 10:00
+date_modified: 2026-04-21 10:00
 date_published: 2019-01-07 10:05
 description: Deploy Trellis WordPress sites to DigitalOcean servers. Create servers, configure settings, and automate WordPress deployment to DigitalOcean.
 title: Deploying Trellis to DigitalOcean
@@ -11,7 +11,7 @@ authors:
 
 [DigitalOcean](https://roots.io/r/digitalocean) is a cloud infrastructure provider that offers virtual servers (droplets) that can handle most normal WordPress sites when provisioned with Trellis.
 
-To provision a server, Trellis requires a server running a bare/stock version of Ubuntu 24.04 LTS.
+To provision a server, Trellis requires a server running a bare/stock version of Ubuntu 26.04 LTS.
 
 ::: tip
 ℹ️ If you [signup for DigitalOcean](https://roots.io/r/digitalocean) through the Roots referral link you will receive a free $200 in credit for 2 months, and you help cover the costs of our hosting.
@@ -90,7 +90,7 @@ Arguments:
 Options:
       --provider        Cloud provider (digitalocean, hetzner)
       --region          Region to create the server in
-      --image           (default: ubuntu-24-04-x64) Server image (ie: Linux distribution)
+      --image           (default: ubuntu-26-04-x64) Server image (ie: Linux distribution)
       --size            Server size/type
       --skip-provision  Skip provision after server is created
       --ssh-key         Path to SSH public key to be added on the server

--- a/trellis/installation.md
+++ b/trellis/installation.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2026-03-06 13:00
+date_modified: 2026-04-21 10:00
 date_published: 2015-10-15 12:20
 description: Install Trellis for WordPress projects. Complete setup instructions covering requirements, dependencies, project initialization, and initial configuration.
 title: Installing Trellis for WordPress
@@ -87,7 +87,7 @@ with a single command thanks to trellis-cli too.
 
 ### Trellis servers are production-ready
 
-Trellis provisions a base Ubuntu 24.04 server by installing and configuring the following software:
+Trellis provisions a base Ubuntu 26.04 server by installing and configuring the following software:
 
 * PHP 8.3+
 * Nginx (including HTTP/2, HTTP/3, and optional FastCGI micro-caching)

--- a/trellis/local-development.md
+++ b/trellis/local-development.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2023-01-27 13:17
+date_modified: 2026-04-21 10:00
 date_published: 2015-10-15 12:24
 description: Trellis uses Lima VM's for local development. Trellis uses Ansible to automatically provision virtual machines running complete WordPress environments.
 title: Local WordPress Development with Trellis
@@ -86,11 +86,11 @@ For the common use case, the default configuration should be all that's needed w
 
 The CLI [config file](cli.md#configuration) (global or project level) supports a new `vm` option. The only useful config option right now is `ubuntu` for setting the Ubuntu version.
 
-Here's an example of specifying 20.04:
+Here's an example of specifying 24.04:
 
 ```yml
 vm:
-  ubuntu: 20.04
+  ubuntu: 24.04
 ```
 
 Note: this must be changed _before_ creating the VM, otherwise you'll need to delete it first and re-create it.

--- a/trellis/python.md
+++ b/trellis/python.md
@@ -1,5 +1,5 @@
 ---
-date_modified: 2023-01-27 13:17
+date_modified: 2026-04-21 10:00
 date_published: 2022-02-28 22:16
 description: Install and configure Python for using Trellis. Python is required for Ansible automation that powers WordPress server provisioning and deployment.
 title: Python Requirements for Trellis
@@ -62,10 +62,10 @@ $ python3 -m ensurepip
 
 ### Ubuntu
 
-Ubuntu 20.04 comes default with Python 3 available as `python3`
+Ubuntu 26.04 comes default with Python 3 available as `python3`
 only. There's no "unversioned" `python`.
 
-The [`python-is-python3`](https://packages.ubuntu.com/focal/python-is-python3) package
+The [`python-is-python3`](https://packages.ubuntu.com/resolute/python-is-python3) package
 exists solely as an easy way to symlink `/usr/bin/python` to `python3`.
 
 ```shell

--- a/trellis/remote-server-setup.md
+++ b/trellis/remote-server-setup.md
@@ -1,7 +1,7 @@
 ---
-date_modified: 2024-09-11 10:00
+date_modified: 2026-04-21 10:00
 date_published: 2015-10-15 12:27
-description: Set up remote servers for Trellis requiring bare Ubuntu 24.04 LTS installation on VPS or dedicated servers. Shared hosting is not supported.
+description: Set up remote servers for Trellis requiring bare Ubuntu 26.04 LTS installation on VPS or dedicated servers. Shared hosting is not supported.
 title: Remote Server Setup for WordPress with Trellis
 authors:
   - ben
@@ -42,10 +42,10 @@ See the [CLI docs](/trellis/docs/cli/) for more details on configuring your clou
 
 ## Server requirements
 
-* Ubuntu 24.04 LTS
+* Ubuntu 26.04 LTS
 * SSH access to the server
 
-You need a server running a bare/stock version of Ubuntu 24.04 LTS. If you're using a host such as DigitalOcean that lets you pick an OS to start with, then select the Ubuntu 24.04 option.
+You need a server running a bare/stock version of Ubuntu 26.04 LTS. If you're using a host such as DigitalOcean that lets you pick an OS to start with, then select the Ubuntu 26.04 option.
 
 You need to be able to connect to your Ubuntu server from your local computer via SSH. We *highly* suggest doing this via SSH keys so you don't have to specify a password every time. Many hosts offer to automatically add your SSH key when creating a server, so take advantage of that. 
 


### PR DESCRIPTION
Prep for Ubuntu 26.04, releasing tomorrow (Apr 22)

[https://canonical.com/blog/ubuntu-26-04-lts-security-update](https://canonical.com/blog/ubuntu-26-04-lts-security-updates)

Ref https://github.com/roots/trellis/pull/1663
Ref https://github.com/roots/trellis-cli/pull/676