### PR TITLE
Bedrock: Create project with `--prefer-source --remove-vcs`

### DIFF
--- a/bedrock/installation.md
+++ b/bedrock/installation.md
@@ -33,7 +33,7 @@ Bedrock is a [WordPress boilerplate](https://roots.io/bedrock/).
 Create a new Bedrock project:
 
 ```shell
-$ composer create-project roots/bedrock
+$ composer create-project --prefer-source --remove-vcs roots/bedrock
 ```
 
 ## Getting Started


### PR DESCRIPTION
Add `--prefer-source --remove-vcs` flags so that users will get [git `export-ignore` files](https://github.com/roots/bedrock/blob/0d38b039ed2f5937b52ca813ca9195de5f63b0cf/.gitattributes#L1-L4).

```console
$ composer create-project --no-install --prefer-source --remove-vcs roots/bedrock with-prefer-source

$ composer create-project --no-install roots/bedrock without-prefer-source

$ diff -qr with-prefer-source without-prefer-source
Only in with-prefer-source: .devcontainer
Only in with-prefer-source: .editorconfig
Only in with-prefer-source: .gitattributes
Only in with-prefer-source: .github
```

---

The `--prefer-source` flag **significantly slows down** the `create-project` command  because it installs dependencies from source as well. Alternatively, we could:

```bash
composer create-project --no-install --prefer-source --remove-vcs roots/bedrock
cd bedrock
composer install
```